### PR TITLE
Feature/impelement ghasedak driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 phpunit.xml.bak
 composer.lock
 test-report.xml
+
+/*-test.php

--- a/README.md
+++ b/README.md
@@ -45,16 +45,27 @@ This is a Laravel Package for Sms Senders Integration. This package supports `La
 
 # List of available drivers
 
-- [fake sms sender](#fake-sms) :heavy_check_mark: (Both: Voice call/Sms)
-- [Avanak](https://www.avanak.ir/) :heavy_check_mark: (Voice call driver)
-- [Kavenegar](https://kavenegar.com/) :heavy_check_mark: (Sms)
-- [Magfa](https://magfa.com/) :heavy_check_mark: (Sms)
-- [Sms Online](https://smsonline.ir/) :heavy_check_mark: (Sms)
+- [fake sms sender](#fake-sms) : (Both: Voice call/Sms)
+- [Avanak](https://www.avanak.ir/) : (Voice call driver)
+- [Ghasedak](https://ghasedak.me/) : (Sms)
+- [Kavenegar](https://kavenegar.com/) : (Sms)
+- [Magfa](https://magfa.com/) : (Sms)
+- [Sms Online](https://smsonline.ir/) : (Sms)
 
 Note: for using each of them check config file and use the needed env in your env file
 like username/password or api key depend on witch driver you use.
 
 Note: to use magfa/sms online/avanak you should install php ext-soap.
+
+**Important:** Some drivers require additional packages. Install the driver package you need:
+
+```bash
+# For Ghasedak driver
+composer require ghasedaksms/php
+
+# For Kavenegar driver
+composer require kavenegar/laravel
+```
 
 ## .env file for each driver:
 
@@ -67,6 +78,19 @@ SMS_DRIVER=fake
 
 FAKE_SENDER_NUMBER=101010
 
+
+### Ghasedak
+// Use in your production .env file if you want to use Ghasedak as default sms driver
+
+SMS_DRIVER=ghasedak
+
+// Your Ghasedak account api key
+
+GHASEDAK_API_KEY=your_api_key
+
+// Your Ghasedak sender number (line number)
+
+GHASEDAK_SENDER_NUMBER=3000xxxxx
 
 ### Kavenegar
 // Use in your production .env file if you want to use Kavenegar as default sms driver
@@ -208,16 +232,24 @@ public function toSms(User $notifiable)
 ```
 #### Change condition of showing sms list page
 
-By default when your laravel application is in production mode this page will response 
-404. But if you want have a diffrent condition publish config file and change this part
-like this code or some thing you want:
+By default when your laravel application is in production mode this page will response 404. You can now control this via `.env` file:
+
+```
+# Set to true to hide the SMS list page (default: true in production)
+DONT_SHOW_SMS_LIST_PAGE=true
+```
+
+Or if you want more control, publish the config file and customize the condition:
 
 ```php
 // default config is:
-'dont_show_sms_list_page_condition' => config('app.env') == 'production',
+'dont_show_sms_list_page_condition' => env(
+    'DONT_SHOW_SMS_LIST_PAGE',
+    env('APP_ENV', 'production') == 'production'
+),
 
 // you can check any thing like domain:
-'dont_show_sms_list_page_condition' => config('app.env') == 'production' || config('app.url') == 'https://yourproductiondomain.com';
+'dont_show_sms_list_page_condition' => env('APP_ENV') == 'production' || config('app.url') == 'https://yourproductiondomain.com',
 
 ```
 now if you forgot to set app.env to production or temporary change it, it will be safe

--- a/README_FA.md
+++ b/README_FA.md
@@ -39,12 +39,22 @@
 
 # لیست درایورهای موجود
 
-- [درایور پیامک fake](#fake-sms) :heavy_check_mark: :بخشی از تست‌های توسعه.
-- [Kavenegar](#kavenegar) :heavy_check_mark:
-- [Mediana](#mediana) :heavy_check_mark:
-- [Sms.ir](#smsir) :heavy_check_mark:
-- [Farazsms](#farazsms) :heavy_check_mark:
-- [Meli Payamak](#meli-payamak) :heavy_check_mark:
+- [درایور پیامک fake](#fake-sms) (هم برای پیامک و هم تماس صوتی)
+- [Avanak](https://www.avanak.ir/) (درایور تماس صوتی)
+- [Ghasedak](https://ghasedak.me/) (پیامک)
+- [Kavenegar](https://kavenegar.com/) (پیامک)
+- [Magfa](https://magfa.com/) (پیامک)
+- [Sms Online](https://smsonline.ir/) (پیامک)
+
+**مهم:** برخی درایورها نیاز به پکیج‌های اضافی دارند. پکیج درایور مورد نیاز خود را نصب کنید:
+
+```bash
+# برای درایور قاصدک
+composer require ghasedaksms/php
+
+# برای درایور کاوه‌نگار
+composer require kavenegar/laravel
+```
 
 # نصب
 
@@ -72,9 +82,47 @@ composer update
 
 این پکیج از پیکربندی‌ها در فایل `.env` پشتیبانی می‌کند. نمونه تنظیمات فایل `.env` به این شکل است:
 
+### درایور fake (برای توسعه و تست)
+```
+SMS_DRIVER=fake
+FAKE_SENDER_NUMBER=101010
+```
+
+### درایور قاصدک (Ghasedak)
+```
+SMS_DRIVER=ghasedak
+GHASEDAK_API_KEY=your_api_key
+GHASEDAK_SENDER_NUMBER=3000xxxxx
+```
+
+### درایور کاوه‌نگار (Kavenegar)
 ```
 SMS_DRIVER=kavenegar
-SMS_API_KEY=کلید API شما
+KAVENEGAR_API_KEY=your_api_key
+```
+
+### درایور مگفا (Magfa)
+```
+SMS_DRIVER=magfa
+SMS_MAGFA_USERNAME=your_username
+SMS_MAGFA_PASSWORD=your_password
+SMS_MAGFA_DOMAIN=your_domain
+SMS_MAGFA_SENDER_NUMBER=your_sender_number
+```
+
+### درایور Sms Online
+```
+SMS_DRIVER=smsonline
+SMS_ONLINE_USERNAME=your_username
+SMS_ONLINE_PASSWORD=your_password
+SMS_ONLINE_SENDER_NUMBER=your_sender_number
+```
+
+### درایور آوانک (Avanak) - تماس صوتی
+```
+VOICE_CALL_DRIVER=avanak
+VOICE_AVANAK_USERNAME=your_username
+VOICE_AVANAK_PASSWORD=your_password
 ```
 
 # نحوه استفاده
@@ -137,6 +185,26 @@ $smsManager = new SmsManager(app());
 $smsManager->extend('myCustomDriver', function ($app) {
     return new MyCustomDriver();
 });
+```
+
+### تغییر شرط نمایش صفحه لیست پیامک‌ها
+
+به طور پیش‌فرض وقتی اپلیکیشن لاراول شما در حالت پروداکشن است، این صفحه 404 برمی‌گرداند.
+می‌توانید این را از طریق فایل `.env` کنترل کنید:
+
+```
+# برای مخفی کردن صفحه لیست پیامک true قرار دهید (پیش‌فرض: true در production)
+DONT_SHOW_SMS_LIST_PAGE=true
+```
+
+یا اگر کنترل بیشتری می‌خواهید، فایل config را publish کرده و شرط را سفارشی کنید:
+
+```php
+// پیکربندی پیش‌فرض:
+'dont_show_sms_list_page_condition' => env(
+    'DONT_SHOW_SMS_LIST_PAGE',
+    env('APP_ENV', 'production') == 'production'
+),
 ```
 
 ### رویدادها

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,11 @@
     ],
     "require": {
         "php": "^8.0.2",
-        "kavenegar/laravel": "*",
-        "laravel/framework": "^8.0|^9.0|^10.0|^11.0|^12.0"
+        "laravel/framework": "^8.0|^9.0|^10.0|^11.0|^12.0",
+    },
+    "suggest": {
+        "ghasedaksms/php": "^1.0",
+        "kavenegar/laravel": "^1.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0|^10.5|^11.5",

--- a/config/sms.php
+++ b/config/sms.php
@@ -52,6 +52,13 @@ return [
             'from'     => env('VOICE_AVANAK_SENDER_NUMBER', ''),
             'wsdl_url' => 'http://portal.avanak.ir/webservice3.asmx?WSDL',
         ],
+        'ghasedak' => [
+            'apiKey' => env('GHASEDAK_API_KEY'),
+            'from' => env('GHASEDAK_SENDER_NUMBER'),
+        ]
     ],
-    'dont_show_sms_list_page_condition' => config('app.env') == 'production',
+    'dont_show_sms_list_page_condition' => env(
+        'DONT_SHOW_SMS_LIST_PAGE',
+        env('APP_ENV', 'production') == 'production'
+    ),
 ];

--- a/config/sms.php
+++ b/config/sms.php
@@ -53,8 +53,8 @@ return [
             'wsdl_url' => 'http://portal.avanak.ir/webservice3.asmx?WSDL',
         ],
         'ghasedak' => [
-            'apiKey' => env('GHASEDAK_API_KEY'),
-            'from' => env('GHASEDAK_SENDER_NUMBER'),
+            'apiKey'   => env('GHASEDAK_API_KEY'),
+            'from'     => env('GHASEDAK_SENDER_NUMBER'),
         ]
     ],
     'dont_show_sms_list_page_condition' => env(

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,16 +7,17 @@
     </testsuite>
   </testsuites>
   <php>
-    <env name="APP_ENV" value="testing"/>
-    <env name="PACKAGE_TESTING" value="true" />
-    <env name="BCRYPT_ROUNDS" value="4"/>
-    <env name="CACHE_DRIVER" value="array"/>
-    <env name="DB_CONNECTION" value="sqlite"/>
-    <env name="DB_DATABASE" value=":memory:"/>
-    <env name="MAIL_MAILER" value="array"/>
-    <env name="QUEUE_CONNECTION" value="sync"/>
-    <env name="SESSION_DRIVER" value="array"/>
-    <env name="TELESCOPE_ENABLED" value="false"/>
+    <server name="APP_ENV" value="testing"/>
+    <server name="PACKAGE_TESTING" value="true" />
+    <server name="BCRYPT_ROUNDS" value="4"/>
+    <server name="CACHE_DRIVER" value="array"/>
+    <server name="DB_CONNECTION" value="sqlite"/>
+    <server name="DB_DATABASE" value=":memory:"/>
+    <server name="MAIL_MAILER" value="array"/>
+    <server name="QUEUE_CONNECTION" value="sync"/>
+    <server name="SESSION_DRIVER" value="array"/>
+    <server name="TELESCOPE_ENABLED" value="false"/>
+    <server name="PULSE_ENABLED" value="false"/>
   </php>
   <source>
     <include>

--- a/src/Drivers/Ghasedak.php
+++ b/src/Drivers/Ghasedak.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace HoomanMirghasemi\Sms\Drivers;
+
+use DateTimeImmutable;
+use Exception;
+use Ghasedak\DataTransferObjects\Request\OtpMessageWithParamsDTO;
+use Ghasedak\DataTransferObjects\Request\ReceptorDTO;
+use Ghasedak\DataTransferObjects\Request\SingleMessageDTO;
+use Ghasedak\GhasedaksmsApi;
+use HoomanMirghasemi\Sms\Abstracts\Driver;
+
+class Ghasedak extends Driver
+{
+    protected string $from = '';
+
+    public function __construct(
+        protected array $settings,
+        private GhasedaksmsApi $ghasedakSmsApi,
+        private ?string $lineNumber = null
+    )
+    {
+        if (!isset($this->lineNumber) && isset($this->settings['from'])) {
+            $this->lineNumber = $this->settings['from'];
+        }
+    }
+
+    public function getBalance(): string
+    {
+        return '';
+    }
+
+    public function send(): bool
+    {
+        if (!$this->serviceActive) {
+            parent::failedConnectToProvider();
+            return false;
+        }
+
+        try {
+            if ($this->message->usesTemplate()) {
+
+                $template = $this->message->getTemplate();
+                $identifier = $template['identifier'];
+                $params = array_values($template['params']);
+
+                $result = $this->ghasedakSmsApi->sendOtpWithParams(
+                    new OtpMessageWithParamsDTO(
+                        new DateTimeImmutable('now'),
+                        [new ReceptorDTO($this->recipient, '1')],
+                        $identifier,
+                        $params[0],
+                        $params[1] ?? null,
+                        $params[2] ?? null,
+                        $params[3] ?? null,
+                        $params[4] ?? null,
+                        $params[5] ?? null,
+                        $params[6] ?? null,
+                        $params[7] ?? null,
+                        $params[8] ?? null,
+                        $params[9] ?? null,
+                    )
+                );
+
+            } else {
+                $result = $this->ghasedakSmsApi->sendSingle(
+                    new SingleMessageDTO(
+                        new DateTimeImmutable('now'),
+                        $this->lineNumber,
+                        $this->recipient,
+                        $this->message->toString()
+                    )
+                );
+            }
+
+            $this->success = $result->getMessageId() !== null;
+            $this->from = $result->getLineNumber();
+            $this->message = $result->getMessage();
+            $this->webserviceResponse = print_r($result, true);
+        } catch (Exception $exception) {
+            $this->webserviceResponse = $exception->getMessage();
+            $this->success = false;
+        }
+
+        return parent::send();
+    }
+}

--- a/src/Drivers/Ghasedak.php
+++ b/src/Drivers/Ghasedak.php
@@ -62,6 +62,10 @@ class Ghasedak extends Driver
                     )
                 );
 
+                $this->success = isset($result);
+                $this->from = '';
+                $this->message = $identifier;
+
             } else {
                 $result = $this->ghasedakSmsApi->sendSingle(
                     new SingleMessageDTO(
@@ -71,12 +75,14 @@ class Ghasedak extends Driver
                         $this->message->toString()
                     )
                 );
+
+                $this->success = $result->getMessageId() !== null;
+                $this->from = $result->getLineNumber();
+                $this->message = $result->getMessage();
             }
 
-            $this->success = $result->getMessageId() !== null;
-            $this->from = $result->getLineNumber();
-            $this->message = $result->getMessage();
             $this->webserviceResponse = print_r($result, true);
+
         } catch (Exception $exception) {
             $this->webserviceResponse = $exception->getMessage();
             $this->success = false;

--- a/src/Providers/SmsProvider.php
+++ b/src/Providers/SmsProvider.php
@@ -4,13 +4,13 @@ namespace HoomanMirghasemi\Sms\Providers;
 
 use HoomanMirghasemi\Sms\Drivers\Avanak;
 use HoomanMirghasemi\Sms\Drivers\FakeSmsSender;
+use HoomanMirghasemi\Sms\Drivers\Ghasedak;
 use HoomanMirghasemi\Sms\Drivers\Kavenegar;
 use HoomanMirghasemi\Sms\Drivers\Magfa;
 use HoomanMirghasemi\Sms\Drivers\SmsOnline;
 use HoomanMirghasemi\Sms\SmsManager;
 use HoomanMirghasemi\Sms\VoiceCallManager;
 use Illuminate\Support\ServiceProvider;
-use Kavenegar\KavenegarApi;
 
 class SmsProvider extends ServiceProvider
 {
@@ -48,13 +48,6 @@ class SmsProvider extends ServiceProvider
             return new FakeSmsSender($config);
         });
 
-        $this->app->bind(Kavenegar::class, function () {
-            $config = config('sms.drivers.kavenegar') ?? [];
-            $kavenegarApi = new KavenegarApi($config['apiKey']);
-
-            return new Kavenegar($config, $kavenegarApi);
-        });
-
         $this->app->bind(Magfa::class, function () {
             $config = config('sms.drivers.magfa') ?? [];
 
@@ -72,6 +65,22 @@ class SmsProvider extends ServiceProvider
 
             return new Avanak($config);
         });
+
+        if (class_exists(\Kavenegar\KavenegarApi::class)) {
+            $this->app->bind(Kavenegar::class, function () {
+                $config = config('sms.drivers.kavenegar') ?? [];
+                $kavenegarApi = new \Kavenegar\KavenegarApi($config['apiKey']);
+                return new Kavenegar($config, $kavenegarApi);
+            });
+        }
+
+        if (class_exists(\Ghasedak\GhasedaksmsApi::class)) {
+            $this->app->bind(Ghasedak::class, function () {
+                $config = config('sms.drivers.ghasedak') ?? [];
+                $ghasedakApi = new \Ghasedak\GhasedaksmsApi($config['apiKey']);
+                return new Ghasedak($config, $ghasedakApi);
+            });
+        }
     }
 
     private function loadMigrations(): self

--- a/src/SmsManager.php
+++ b/src/SmsManager.php
@@ -3,6 +3,7 @@
 namespace HoomanMirghasemi\Sms;
 
 use HoomanMirghasemi\Sms\Drivers\FakeSmsSender;
+use HoomanMirghasemi\Sms\Drivers\Ghasedak;
 use HoomanMirghasemi\Sms\Drivers\Kavenegar;
 use HoomanMirghasemi\Sms\Drivers\Magfa;
 use HoomanMirghasemi\Sms\Drivers\SmsOnline;
@@ -49,6 +50,16 @@ class SmsManager extends Manager
     protected function createMagfaDriver()
     {
         return $this->container->make(Magfa::class);
+    }
+
+    /**
+     * Create an instance of the ghasedak sms sender driver.
+     *
+     * @return Ghasedak
+     */
+    protected function createGhasedakDriver(): Ghasedak
+    {
+        return $this->container->make(Ghasedak::class);
     }
 
     /**

--- a/tests/Feature/Drivers/GhasedakTest.php
+++ b/tests/Feature/Drivers/GhasedakTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace HoomanMirghasemi\Sms\Tests\Feature\Drivers;
+
+use HoomanMirghasemi\Sms\Drivers\Ghasedak;
+use HoomanMirghasemi\Sms\Message;
+use HoomanMirghasemi\Sms\Tests\TestCase;
+use Mockery\MockInterface;
+
+class GhasedakTest extends TestCase
+{
+    private string $mobile = '+98935123456';
+
+    public function testSuccessSend()
+    {
+        /** @var Ghasedak $ghasedakStub */
+        $ghasedakStub = $this->partialMock(Ghasedak::class, function (MockInterface $mock) {
+            $mock->shouldReceive('send')
+                ->once()
+                ->andReturnTrue();
+        });
+
+        $result = $ghasedakStub->to($this->mobile)
+            ->message('Test ghasedak sms')
+            ->send();
+
+        $this->assertTrue($result);
+    }
+
+    public function testSuccessSendWithMessageTemplate()
+    {
+        /** @var Ghasedak $ghasedakStub */
+        $ghasedakStub = $this->partialMock(Ghasedak::class, function (MockInterface $mock) {
+            $mock->shouldReceive('send')
+                ->once()
+                ->andReturnTrue();
+        });
+
+        $code = '233269';
+        $message = 'کد تایید ارسال شده ';
+        $message = new Message($message.PHP_EOL.$code);
+        $message->useTemplateIfSupports('SmsRegisterSuccess', [
+            'token1' => $code,
+        ]);
+
+        $result = $ghasedakStub->to($this->mobile)
+            ->message($message)
+            ->send();
+
+        $this->assertTrue($result);
+    }
+}


### PR DESCRIPTION
Summary

  - Implement Ghasedak SMS driver with support for both single SMS and OTP template messages
  - Move kavenegar/laravel from required to suggested dependencies (optional installation)
  - Add ghasedaksms/php as required dependency for Ghasedak driver
  - Add DONT_SHOW_SMS_LIST_PAGE environment variable for easier configuration
  - Update documentation (README.md and README_FA.md) with:
    - Ghasedak driver setup and usage instructions
    - Optional driver package installation requirements
    - New environment variable documentation

  Changes

  - New Driver: src/Drivers/Ghasedak.php - Ghasedak SMS driver implementation
  - Config: Added Ghasedak configuration to config/sms.php
  - Service Provider: Register Ghasedak driver with conditional class existence check
  - SmsManager: Added createGhasedakDriver() method
  - Tests: Added feature tests for Ghasedak driver
  - Docs: Updated both English and Persian README files

  Test plan

  - Run composer install and verify dependencies
  - Run ./vendor/bin/phpunit to execute tests
  - Test Ghasedak driver with real API credentials (single SMS)
  - Test Ghasedak driver with OTP template
  - Verify Kavenegar still works after moving to suggest