### PR TITLE
Refactor Ghasedak driver to use custom HTTP client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 /vendor/
 /.idea
 /.phpunit.cache/
+clover.xml
+coverage.cov
+coverage.txt
+/coverage-report
 .phpunit.result.cache
 phpunit.xml.bak
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -33,10 +33,10 @@
         "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0",
         "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0",
         "illuminate/notifications": "^8.0|^9.0|^10.0|^11.0|^12.0",
-        "illuminate/config": "^8.0|^9.0|^10.0|^11.0|^12.0"
+        "illuminate/config": "^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/http": "^8.0|^9.0|^10.0|^11.0|^12.0"
     },
     "suggest": {
-        "ghasedaksms/php": "^1.0",
         "kavenegar/laravel": "^1.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -41,9 +41,9 @@
         "kavenegar/laravel": "^1.3"
     },
     "require-dev": {
+        "laravel/legacy-factories": "^1.4",
         "orchestra/testbench": "^6.40 | ^7.37 | ^8.17 | ^9.0 | ^10.0",
-        "phpunit/phpunit": "^9.5.10 | ^10.5 | ^11.5",
-        "laravel/legacy-factories": "^1.4"
+        "phpunit/phpunit": "^9.5.10 | ^10.5 | ^11.5"
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
     ],
     "require": {
         "php": "^8.0.2",
+        "guzzlehttp/guzzle": "^7.2",
         "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0",
         "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0",
         "illuminate/notifications": "^8.0|^9.0|^10.0|^11.0|^12.0",

--- a/config/sms.php
+++ b/config/sms.php
@@ -53,6 +53,7 @@ return [
             'wsdl_url' => 'http://portal.avanak.ir/webservice3.asmx?WSDL',
         ],
         'ghasedak' => [
+            'base_api_url' => env('GHASEDAK_BASE_API_URL', 'https://gateway.ghasedak.me/rest/api/v1/WebService'),
             'apiKey'   => env('GHASEDAK_API_KEY'),
             'from'     => env('GHASEDAK_SENDER_NUMBER'),
         ],

--- a/config/sms.php
+++ b/config/sms.php
@@ -53,9 +53,9 @@ return [
             'wsdl_url' => 'http://portal.avanak.ir/webservice3.asmx?WSDL',
         ],
         'ghasedak' => [
-            'base_api_url' => env('GHASEDAK_BASE_API_URL', 'https://gateway.ghasedak.me/rest/api/v1/WebService'),
-            'apiKey'   => env('GHASEDAK_API_KEY'),
-            'from'     => env('GHASEDAK_SENDER_NUMBER'),
+            'base_api_url'  => env('GHASEDAK_BASE_API_URL', 'https://gateway.ghasedak.me/rest/api/v1/WebService'),
+            'apiKey'        => env('GHASEDAK_API_KEY'),
+            'from'          => env('GHASEDAK_SENDER_NUMBER'),
         ],
     ],
     'dont_show_sms_list_page_condition' => env(

--- a/config/sms.php
+++ b/config/sms.php
@@ -53,13 +53,13 @@ return [
             'wsdl_url' => 'http://portal.avanak.ir/webservice3.asmx?WSDL',
         ],
         'ghasedak' => [
-            'base_api_url'  => env('GHASEDAK_BASE_API_URL', 'https://gateway.ghasedak.me/rest/api/v1/WebService'),
-            'apiKey'        => env('GHASEDAK_API_KEY'),
-            'from'          => env('GHASEDAK_SENDER_NUMBER'),
+            'base_api_url' => env('GHASEDAK_BASE_API_URL', 'https://gateway.ghasedak.me/rest/api/v1/WebService'),
+            'apiKey'       => env('GHASEDAK_API_KEY'),
+            'from'         => env('GHASEDAK_SENDER_NUMBER'),
         ],
     ],
     'dont_show_sms_list_page_condition' => env(
         'DONT_SHOW_SMS_LIST_PAGE',
-        env('APP_ENV', 'production') == 'production'
+        'production' == env('APP_ENV', 'production'),
     ),
 ];

--- a/database/migrations/2021_10_03_164841_create_sms_report_table.php
+++ b/database/migrations/2021_10_03_164841_create_sms_report_table.php
@@ -9,8 +9,6 @@ use Illuminate\Support\Facades\Schema;
 return new class() extends Migration {
     /**
      * Run the migrations.
-     *
-     * @return void
      */
     public function up(): void
     {
@@ -28,8 +26,6 @@ return new class() extends Migration {
 
     /**
      * Reverse the migrations.
-     *
-     * @return void
      */
     public function down(): void
     {

--- a/database/migrations/2021_10_03_164841_create_sms_report_table.php
+++ b/database/migrations/2021_10_03_164841_create_sms_report_table.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
 // migrated up don't touch
-return new class extends Migration {
+return new class() extends Migration {
     /**
      * Run the migrations.
      */

--- a/database/migrations/2021_10_03_164841_create_sms_report_table.php
+++ b/database/migrations/2021_10_03_164841_create_sms_report_table.php
@@ -6,11 +6,9 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
 // migrated up don't touch
-return new class() extends Migration {
+return new class extends Migration {
     /**
      * Run the migrations.
-     *
-     * @return void
      */
     public function up(): void
     {
@@ -28,8 +26,6 @@ return new class() extends Migration {
 
     /**
      * Reverse the migrations.
-     *
-     * @return void
      */
     public function down(): void
     {

--- a/database/seeders/SmsDatabaseSeeder.php
+++ b/database/seeders/SmsDatabaseSeeder.php
@@ -2,7 +2,7 @@
 
 namespace HoomanMirghasemi\Sms\Database\Seeders;
 
-//use App\Models\Setting;
+// use App\Models\Setting;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Seeder;
 
@@ -17,13 +17,13 @@ class SmsDatabaseSeeder extends Seeder
     {
         Model::unguard();
 
-//        $params = [
-//            [ 'name' => "default_sms_driver" , 'value' => 'magfa' ],
-//            [ 'name' => "default_voice_call_driver" , 'value' => 'avanak' ],
-//        ];
-//
-//        foreach ($params as $param) {
-//            Setting::create(['name' => $param['name'] , 'value' => $param['value']]);
-//        }
+        //        $params = [
+        //            [ 'name' => "default_sms_driver" , 'value' => 'magfa' ],
+        //            [ 'name' => "default_voice_call_driver" , 'value' => 'avanak' ],
+        //        ];
+        //
+        //        foreach ($params as $param) {
+        //            Setting::create(['name' => $param['name'] , 'value' => $param['value']]);
+        //        }
     }
 }

--- a/src/Abstracts/Driver.php
+++ b/src/Abstracts/Driver.php
@@ -12,8 +12,6 @@ abstract class Driver implements DriverContract
 {
     /**
      * If it can not connect to provider this get false value.
-     *
-     * @var bool
      */
     protected bool $serviceActive = true;
 
@@ -33,31 +31,21 @@ abstract class Driver implements DriverContract
 
     /**
      * Message.
-     *
-     * @var Message|string
      */
     protected Message|string $message;
 
     /**
      * The response of driver webservice of sending message.
-     *
-     * @var string
      */
     protected string $webserviceResponse;
 
     /**
      * Result of sending message.
-     *
-     * @var bool
      */
     protected ?bool $success = null;
 
     /**
      * Add recipient (phone or mobile numbers).
-     *
-     * @param string $recipient
-     *
-     * @return self
      */
     public function to(string $recipient): self
     {
@@ -68,8 +56,6 @@ abstract class Driver implements DriverContract
 
     /**
      * Get recipient mobile number.
-     *
-     * @return string
      */
     public function getRecipient(): string
     {
@@ -78,8 +64,6 @@ abstract class Driver implements DriverContract
 
     /**
      * Get sender number (from attribute).
-     *
-     * @return string
      */
     public function getSenderNumber(): string
     {
@@ -90,8 +74,6 @@ abstract class Driver implements DriverContract
      * Set related message.
      *
      * @param Message $message
-     *
-     * @return self
      */
     public function message(Message|string $message): self
     {
@@ -102,8 +84,6 @@ abstract class Driver implements DriverContract
 
     /**
      * Get message in string.
-     *
-     * @return string
      */
     public function getMessage(): string
     {
@@ -116,8 +96,6 @@ abstract class Driver implements DriverContract
 
     /**
      * Get result of sending message is successful or not.
-     *
-     * @return bool
      */
     public function getResult(): bool
     {
@@ -126,8 +104,6 @@ abstract class Driver implements DriverContract
 
     /**
      * Get webservice response.
-     *
-     * @return string
      */
     public function getWebServiceResponce(): string
     {
@@ -139,12 +115,10 @@ abstract class Driver implements DriverContract
      * This fire SmsSentEvent.
      *
      * @see SmsSentEvent
-     *
-     * @return bool
      */
     public function send(): bool
     {
-        if ($this->success === null) {
+        if (null === $this->success) {
             throw new \BadMethodCallException('Abstract driver send method should only call in end of drivers with result of send');
         }
 

--- a/src/Channels/SmsChannel.php
+++ b/src/Channels/SmsChannel.php
@@ -2,7 +2,6 @@
 
 namespace HoomanMirghasemi\Sms\Channels;
 
-use Exception;
 use HoomanMirghasemi\Sms\Abstracts\Driver;
 use HoomanMirghasemi\Sms\SmsManager;
 use Illuminate\Notifications\Notification;
@@ -12,17 +11,12 @@ class SmsChannel
     /**
      * Send notification.
      *
-     * @param              $notifiable
-     * @param Notification $notification
-     *
-     * @throws Exception
-     *
-     * @return void
+     * @throws \Exception
      */
     public function send($notifiable, Notification $notification): void
     {
         $manager = $notification->toSms($notifiable);
-        if (!is_null($manager)) {
+        if (! is_null($manager)) {
             $this->validate($manager);
             $manager->send();
         }
@@ -31,14 +25,12 @@ class SmsChannel
     /**
      * Validate sms.
      *
-     * @throws Exception
-     *
-     * @return void
+     * @throws \Exception
      */
     protected function validate($manager): void
     {
-        if (!$manager instanceof SmsManager && !$manager instanceof Driver) {
-            throw new Exception('Invalid data for sms notification.');
+        if (! $manager instanceof SmsManager && ! $manager instanceof Driver) {
+            throw new \Exception('Invalid data for sms notification.');
         }
     }
 }

--- a/src/Channels/SmsChannel.php
+++ b/src/Channels/SmsChannel.php
@@ -2,7 +2,6 @@
 
 namespace HoomanMirghasemi\Sms\Channels;
 
-use Exception;
 use HoomanMirghasemi\Sms\Abstracts\Driver;
 use HoomanMirghasemi\Sms\SmsManager;
 use Illuminate\Notifications\Notification;
@@ -12,12 +11,7 @@ class SmsChannel
     /**
      * Send notification.
      *
-     * @param              $notifiable
-     * @param Notification $notification
-     *
-     * @throws Exception
-     *
-     * @return void
+     * @throws \Exception
      */
     public function send($notifiable, Notification $notification): void
     {
@@ -31,14 +25,12 @@ class SmsChannel
     /**
      * Validate sms.
      *
-     * @throws Exception
-     *
-     * @return void
+     * @throws \Exception
      */
     protected function validate($manager): void
     {
         if (!$manager instanceof SmsManager && !$manager instanceof Driver) {
-            throw new Exception('Invalid data for sms notification.');
+            throw new \Exception('Invalid data for sms notification.');
         }
     }
 }

--- a/src/Channels/VoiceCallChannel.php
+++ b/src/Channels/VoiceCallChannel.php
@@ -2,7 +2,6 @@
 
 namespace HoomanMirghasemi\Sms\Channels;
 
-use Exception;
 use HoomanMirghasemi\Sms\Abstracts\Driver;
 use HoomanMirghasemi\Sms\VoiceCallManager;
 use Illuminate\Notifications\Notification;
@@ -12,12 +11,7 @@ class VoiceCallChannel
     /**
      * Send notification.
      *
-     * @param              $notifiable
-     * @param Notification $notification
-     *
-     * @throws Exception
-     *
-     * @return void
+     * @throws \Exception
      */
     public function send($notifiable, Notification $notification): void
     {
@@ -31,14 +25,12 @@ class VoiceCallChannel
     /**
      * Validate sms.
      *
-     * @throws Exception
-     *
-     * @return void
+     * @throws \Exception
      */
     protected function validate($manager): void
     {
         if (!$manager instanceof VoiceCallManager && !$manager instanceof Driver) {
-            throw new Exception('Invalid data for voice call notification.');
+            throw new \Exception('Invalid data for voice call notification.');
         }
     }
 }

--- a/src/Channels/VoiceCallChannel.php
+++ b/src/Channels/VoiceCallChannel.php
@@ -2,7 +2,6 @@
 
 namespace HoomanMirghasemi\Sms\Channels;
 
-use Exception;
 use HoomanMirghasemi\Sms\Abstracts\Driver;
 use HoomanMirghasemi\Sms\VoiceCallManager;
 use Illuminate\Notifications\Notification;
@@ -12,17 +11,12 @@ class VoiceCallChannel
     /**
      * Send notification.
      *
-     * @param              $notifiable
-     * @param Notification $notification
-     *
-     * @throws Exception
-     *
-     * @return void
+     * @throws \Exception
      */
     public function send($notifiable, Notification $notification): void
     {
         $manager = $notification->toVoiceCall($notifiable);
-        if (!is_null($manager)) {
+        if (! is_null($manager)) {
             $this->validate($manager);
             $manager->send();
         }
@@ -31,14 +25,12 @@ class VoiceCallChannel
     /**
      * Validate sms.
      *
-     * @throws Exception
-     *
-     * @return void
+     * @throws \Exception
      */
     protected function validate($manager): void
     {
-        if (!$manager instanceof VoiceCallManager && !$manager instanceof Driver) {
-            throw new Exception('Invalid data for voice call notification.');
+        if (! $manager instanceof VoiceCallManager && ! $manager instanceof Driver) {
+            throw new \Exception('Invalid data for voice call notification.');
         }
     }
 }

--- a/src/Clients/GhasedakClient.php
+++ b/src/Clients/GhasedakClient.php
@@ -16,10 +16,9 @@ class GhasedakClient
     public function __construct(string $baseApiUrl, string $apiKey)
     {
         $this->http = Http::baseUrl($baseApiUrl)
-            ->withHeader('ApiKey', $apiKey)
+            ->withHeaders(['ApiKey' => $apiKey])
             ->accept('text/plain')
-            ->timeout(20) // 20 seconds wait for client response
-            ->connectTimeout(20) // 20 seconds wait for connection to third party service
+            ->timeout(20) // 20 seconds wait for response
             ->throw();  // If you get error throw a exception from type below
                         // Illuminate\Http\Client\ConnectionException
                         // Illuminate\Http\Client\RequestException

--- a/src/Clients/GhasedakClient.php
+++ b/src/Clients/GhasedakClient.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace HoomanMirghasemi\Sms\Clients;
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+
+class GhasedakClient
+{
+    protected PendingRequest $http;
+
+    public function __construct(string $baseApiUrl, string $apiKey)
+    {
+        $this->http = Http::baseUrl($baseApiUrl)
+            ->withHeader('ApiKey', $apiKey)
+            ->accept('text/plain')
+            ->timeout(20) // 20 seconds wait for client response
+            ->connectTimeout(20) // 20 seconds wait for connection to third party service
+            ->throw();  // If you get error throw a exception from type below
+                        // Illuminate\Http\Client\ConnectionException
+                        // Illuminate\Http\Client\RequestException
+    }
+
+
+    /**
+     * @return PromiseInterface|Response
+     * @throws ConnectionException|RequestException
+     */
+    public function getAccountInformation(): PromiseInterface|Response
+    {
+        return $this->http->get('GetAccountInformation');
+    }
+
+    /**
+     * @param string $lineNumber
+     * @param string $receptor
+     * @param string $message
+     * @return PromiseInterface|Response
+     * @throws ConnectionException|RequestException
+     */
+    public function sendSingleSMS(string $lineNumber, string $receptor, string $message): PromiseInterface|Response
+    {
+        return $this->http->post('SendSingleSMS', [
+            'lineNumber' => $lineNumber,
+            'receptor' => $receptor,
+            'message' => $message
+        ]);
+    }
+
+    public function sendOtpWithParams(string $templateName, string $receptor, ...$params): PromiseInterface|Response
+    {
+        $parameters = [];
+
+        foreach ($params as $index => $param) {
+            if ( $param == null ) { continue; }
+            $parameters["param" . $index + 1] = $param;
+        }
+
+        return $this->http->post('SendOtpWithParams', array_merge([
+            'receptors' => [[
+                'mobile' => $receptor,
+                'clientReferenceId' => "$receptor:" . time()
+            ]],
+            'templateName' => $templateName,
+        ], $parameters));
+    }
+}

--- a/src/Clients/GhasedakClient.php
+++ b/src/Clients/GhasedakClient.php
@@ -16,7 +16,7 @@ class GhasedakClient
     public function __construct(string $baseApiUrl, string $apiKey)
     {
         $this->http = Http::baseUrl($baseApiUrl)
-            ->withHeader('ApiKey', $apiKey)
+            ->withHeaders(['ApiKey' => $apiKey])
             ->accept('text/plain')
             ->timeout(20) // 20 seconds wait for client response
             ->connectTimeout(20) // 20 seconds wait for connection to third party service

--- a/src/Clients/GhasedakClient.php
+++ b/src/Clients/GhasedakClient.php
@@ -18,10 +18,7 @@ class GhasedakClient
         $this->http = Http::baseUrl($baseApiUrl)
             ->withHeaders(['ApiKey' => $apiKey])
             ->accept('text/plain')
-            ->timeout(20) // 20 seconds wait for response
-            ->throw();  // If you get error throw a exception from type below
-                        // Illuminate\Http\Client\ConnectionException
-                        // Illuminate\Http\Client\RequestException
+            ->timeout(20); // 20 seconds wait for response
     }
 
 

--- a/src/Clients/GhasedakClient.php
+++ b/src/Clients/GhasedakClient.php
@@ -4,8 +4,8 @@ namespace HoomanMirghasemi\Sms\Clients;
 
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\ConnectionException;
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
 
@@ -21,10 +21,10 @@ class GhasedakClient
             ->timeout(20); // 20 seconds wait for response
     }
 
-
     /**
-     * @return PromiseInterface|Response
      * @throws ConnectionException|RequestException
+     *
+     * @return PromiseInterface|Response
      */
     public function getAccountInformation(): PromiseInterface|Response
     {
@@ -35,15 +35,17 @@ class GhasedakClient
      * @param string $lineNumber
      * @param string $receptor
      * @param string $message
-     * @return PromiseInterface|Response
+     *
      * @throws ConnectionException|RequestException
+     *
+     * @return PromiseInterface|Response
      */
     public function sendSingleSMS(string $lineNumber, string $receptor, string $message): PromiseInterface|Response
     {
         return $this->http->post('SendSingleSMS', [
             'lineNumber' => $lineNumber,
-            'receptor' => $receptor,
-            'message' => $message
+            'receptor'   => $receptor,
+            'message'    => $message,
         ]);
     }
 
@@ -52,14 +54,16 @@ class GhasedakClient
         $parameters = [];
 
         foreach ($params as $index => $param) {
-            if ( $param == null ) { continue; }
-            $parameters["param" . $index + 1] = $param;
+            if ($param == null) {
+                continue;
+            }
+            $parameters['param'.$index + 1] = $param;
         }
 
         return $this->http->post('SendOtpWithParams', array_merge([
             'receptors' => [[
-                'mobile' => $receptor,
-                'clientReferenceId' => "$receptor:" . time()
+                'mobile'            => $receptor,
+                'clientReferenceId' => "$receptor:".time(),
             ]],
             'templateName' => $templateName,
         ], $parameters));

--- a/src/Clients/GhasedakClient.php
+++ b/src/Clients/GhasedakClient.php
@@ -23,8 +23,6 @@ class GhasedakClient
 
     /**
      * @throws ConnectionException|RequestException
-     *
-     * @return PromiseInterface|Response
      */
     public function getAccountInformation(): PromiseInterface|Response
     {
@@ -32,13 +30,7 @@ class GhasedakClient
     }
 
     /**
-     * @param string $lineNumber
-     * @param string $receptor
-     * @param string $message
-     *
      * @throws ConnectionException|RequestException
-     *
-     * @return PromiseInterface|Response
      */
     public function sendSingleSMS(string $lineNumber, string $receptor, string $message): PromiseInterface|Response
     {
@@ -54,7 +46,7 @@ class GhasedakClient
         $parameters = [];
 
         foreach ($params as $index => $param) {
-            if ($param == null) {
+            if (null == $param) {
                 continue;
             }
             $parameters['param'.$index + 1] = $param;

--- a/src/Contracts/Driver.php
+++ b/src/Contracts/Driver.php
@@ -6,33 +6,21 @@ interface Driver
 {
     /**
      * Add recipient (mobile numbers).
-     *
-     * @param string $recipient
-     *
-     * @return self
      */
     public function to(string $recipient): self;
 
     /**
      * Set related message.
-     *
-     * @param Message $message
-     *
-     * @return self
      */
     public function message(Message $message): self;
 
     /**
      * Send message to recipient.
-     *
-     * @return bool
      */
     public function send(): bool;
 
     /**
      * Get remaining balance of driver.
-     *
-     * @return string
      */
     public function getBalance(): string;
 }

--- a/src/Contracts/Message.php
+++ b/src/Contracts/Message.php
@@ -6,8 +6,6 @@ interface Message
 {
     /**
      * Retrieve string format of message.
-     *
-     * @return string
      */
     public function toString(): string;
 }

--- a/src/Drivers/Avanak.php
+++ b/src/Drivers/Avanak.php
@@ -2,15 +2,13 @@
 
 namespace HoomanMirghasemi\Sms\Drivers;
 
-use Exception;
 use HoomanMirghasemi\Sms\Abstracts\Driver;
 use Illuminate\Support\Facades\Log;
 use SoapClient;
-use SoapFault;
 
 class Avanak extends Driver
 {
-    private SoapClient $client;
+    private \SoapClient $client;
 
     private array $params;
 
@@ -30,19 +28,17 @@ class Avanak extends Driver
      * Send voice call method for Avanak.
      *
      * This method send sms and save log to db.
-     *
-     * @return bool
      */
     public function send(): bool
     {
-        if (!$this->serviceActive) {
+        if (! $this->serviceActive) {
             parent::failedConnectToProvider();
 
             return false;
         }
         $this->params['text'] = $this->getMessage();
         $this->params['number'] = $this->recipient;
-        if (!str_starts_with($this->params['number'], '+98')) {
+        if (! str_starts_with($this->params['number'], '+98')) {
             return false;
         }
         // for sending to avanak change number format
@@ -57,7 +53,7 @@ class Avanak extends Driver
                 $this->webserviceResponse = 'Error Code : '.$response->QuickSendWithTTSResult;
                 $this->success = false;
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $this->webserviceResponse = 'code:'.$e->getCode().' message: '.$e->getMessage();
             $this->success = false;
         }
@@ -67,12 +63,10 @@ class Avanak extends Driver
 
     /**
      * Return the remaining balance of avanak.
-     *
-     * @return string
      */
     public function getBalance(): string
     {
-        if (!$this->serviceActive) {
+        if (! $this->serviceActive) {
             return 'وب سرویس آوانک با مشکل مواجه شده.';
         }
 
@@ -80,21 +74,19 @@ class Avanak extends Driver
             $response = $this->client->GetCredit($this->params);
 
             return $response->GetCreditResult;
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return 'message:'.$e->getMessage().' code: '.$e->getCode();
         }
     }
 
     /**
      * Make SoapClient object and connect to avanak wsdl webservices.
-     *
-     * @return void
      */
     private function tryConnectToProvider(): void
     {
         try {
-            $this->client = new SoapClient(data_get($this->settings, 'wsdl_url'), ['trace' => 1, 'encoding' => 'UTF-8']);
-        } catch (SoapFault $soapFault) {
+            $this->client = new \SoapClient(data_get($this->settings, 'wsdl_url'), ['trace' => 1, 'encoding' => 'UTF-8']);
+        } catch (\SoapFault $soapFault) {
             Log::error('avanak voice call code: '.$soapFault->getCode().' message: '.$soapFault->getMessage());
             $this->serviceActive = false;
         }

--- a/src/Drivers/Avanak.php
+++ b/src/Drivers/Avanak.php
@@ -31,14 +31,14 @@ class Avanak extends Driver
      */
     public function send(): bool
     {
-        if (! $this->serviceActive) {
+        if (!$this->serviceActive) {
             parent::failedConnectToProvider();
 
             return false;
         }
         $this->params['text'] = $this->getMessage();
         $this->params['number'] = $this->recipient;
-        if (! str_starts_with($this->params['number'], '+98')) {
+        if (!str_starts_with($this->params['number'], '+98')) {
             return false;
         }
         // for sending to avanak change number format
@@ -66,7 +66,7 @@ class Avanak extends Driver
      */
     public function getBalance(): string
     {
-        if (! $this->serviceActive) {
+        if (!$this->serviceActive) {
             return 'وب سرویس آوانک با مشکل مواجه شده.';
         }
 

--- a/src/Drivers/Avanak.php
+++ b/src/Drivers/Avanak.php
@@ -2,15 +2,13 @@
 
 namespace HoomanMirghasemi\Sms\Drivers;
 
-use Exception;
 use HoomanMirghasemi\Sms\Abstracts\Driver;
 use Illuminate\Support\Facades\Log;
 use SoapClient;
-use SoapFault;
 
 class Avanak extends Driver
 {
-    private SoapClient $client;
+    private \SoapClient $client;
 
     private array $params;
 
@@ -30,8 +28,6 @@ class Avanak extends Driver
      * Send voice call method for Avanak.
      *
      * This method send sms and save log to db.
-     *
-     * @return bool
      */
     public function send(): bool
     {
@@ -57,7 +53,7 @@ class Avanak extends Driver
                 $this->webserviceResponse = 'Error Code : '.$response->QuickSendWithTTSResult;
                 $this->success = false;
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $this->webserviceResponse = 'code:'.$e->getCode().' message: '.$e->getMessage();
             $this->success = false;
         }
@@ -67,8 +63,6 @@ class Avanak extends Driver
 
     /**
      * Return the remaining balance of avanak.
-     *
-     * @return string
      */
     public function getBalance(): string
     {
@@ -80,21 +74,19 @@ class Avanak extends Driver
             $response = $this->client->GetCredit($this->params);
 
             return $response->GetCreditResult;
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return 'message:'.$e->getMessage().' code: '.$e->getCode();
         }
     }
 
     /**
      * Make SoapClient object and connect to avanak wsdl webservices.
-     *
-     * @return void
      */
     private function tryConnectToProvider(): void
     {
         try {
-            $this->client = new SoapClient(data_get($this->settings, 'wsdl_url'), ['trace' => 1, 'encoding' => 'UTF-8']);
-        } catch (SoapFault $soapFault) {
+            $this->client = new \SoapClient(data_get($this->settings, 'wsdl_url'), ['trace' => 1, 'encoding' => 'UTF-8']);
+        } catch (\SoapFault $soapFault) {
             Log::error('avanak voice call code: '.$soapFault->getCode().' message: '.$soapFault->getMessage());
             $this->serviceActive = false;
         }

--- a/src/Drivers/FakeSmsSender.php
+++ b/src/Drivers/FakeSmsSender.php
@@ -8,8 +8,6 @@ class FakeSmsSender extends Driver
 {
     /**
      * The Faker sms send sms success of fail.
-     *
-     * @var bool
      */
     public static bool $successSend = true;
 
@@ -22,8 +20,6 @@ class FakeSmsSender extends Driver
      * Send sms method for Magfa.
      *
      * This method send sms and save log to db.
-     *
-     * @return bool
      */
     public function send(): bool
     {
@@ -40,8 +36,6 @@ class FakeSmsSender extends Driver
 
     /**
      * Return fake balance :D.
-     *
-     * @return string
      */
     public function getBalance(): string
     {

--- a/src/Drivers/FakeSmsSender.php
+++ b/src/Drivers/FakeSmsSender.php
@@ -23,7 +23,7 @@ class FakeSmsSender extends Driver
      */
     public function send(): bool
     {
-        if (! self::$successSend) {
+        if (!self::$successSend) {
             $this->webserviceResponse = 'An error happened !';
             $this->success = false;
         } else {

--- a/src/Drivers/FakeSmsSender.php
+++ b/src/Drivers/FakeSmsSender.php
@@ -8,8 +8,6 @@ class FakeSmsSender extends Driver
 {
     /**
      * The Faker sms send sms success of fail.
-     *
-     * @var bool
      */
     public static bool $successSend = true;
 
@@ -22,12 +20,10 @@ class FakeSmsSender extends Driver
      * Send sms method for Magfa.
      *
      * This method send sms and save log to db.
-     *
-     * @return bool
      */
     public function send(): bool
     {
-        if (!self::$successSend) {
+        if (! self::$successSend) {
             $this->webserviceResponse = 'An error happened !';
             $this->success = false;
         } else {
@@ -40,8 +36,6 @@ class FakeSmsSender extends Driver
 
     /**
      * Return fake balance :D.
-     *
-     * @return string
      */
     public function getBalance(): string
     {

--- a/src/Drivers/Ghasedak.php
+++ b/src/Drivers/Ghasedak.php
@@ -30,6 +30,7 @@ class Ghasedak extends Driver
     {
         if (!$this->serviceActive) {
             parent::failedConnectToProvider();
+
             return '';
         }
 
@@ -37,17 +38,16 @@ class Ghasedak extends Driver
             $response = $this->ghasedakClient->getAccountInformation();
 
             if ($response->failed()) {
-                throw new Exception("HTTP request failed with status: " . $response->status(), $response->status());
+                throw new Exception('HTTP request failed with status: '.$response->status(), $response->status());
             }
 
             $accountInfo = $response->json();
 
             if (!$accountInfo['isSuccess']) {
-                throw new Exception("Ghasedak responded with an error: " . $accountInfo['message'], $accountInfo['statusCode']);
+                throw new Exception('Ghasedak responded with an error: '.$accountInfo['message'], $accountInfo['statusCode']);
             }
 
             return $accountInfo['data']['credit'] ?? '';
-
         } catch (Exception $e) {
             return 'message:'.$e->getMessage().' code: '.$e->getCode();
         }
@@ -57,6 +57,7 @@ class Ghasedak extends Driver
     {
         if (!$this->serviceActive) {
             parent::failedConnectToProvider();
+
             return false;
         }
 
@@ -82,33 +83,33 @@ class Ghasedak extends Driver
                 );
 
                 if ($response->failed()) {
-                    throw new Exception("HTTP request failed with status: " . $response->status(), $response->status());
+                    throw new Exception('HTTP request failed with status: '.$response->status(), $response->status());
                 }
 
                 $result = $response->json();
 
                 if (!$result['isSuccess']) {
-                    throw new Exception("Ghasedak responded with an error: " . $result['message'], $result['statusCode']);
+                    throw new Exception('Ghasedak responded with an error: '.$result['message'], $result['statusCode']);
                 }
 
                 $this->success = true;
                 $this->from = $identifier;
                 $this->message = $result['message'];
-
             } else {
-
                 $response = $this->ghasedakClient->sendSingleSMS(
-                    $this->lineNumber, $this->recipient, $this->message->toString()
+                    $this->lineNumber,
+                    $this->recipient,
+                    $this->message->toString()
                 );
 
                 if ($response->failed()) {
-                    throw new Exception("HTTP request failed with status: " . $response->status(), $response->status());
+                    throw new Exception('HTTP request failed with status: '.$response->status(), $response->status());
                 }
 
                 $result = $response->json();
 
                 if (!$result['isSuccess']) {
-                    throw new Exception("Ghasedak responded with an error: " . $result['message'], $result['statusCode']);
+                    throw new Exception('Ghasedak responded with an error: '.$result['message'], $result['statusCode']);
                 }
 
                 $this->success = true;

--- a/src/Drivers/Ghasedak.php
+++ b/src/Drivers/Ghasedak.php
@@ -2,7 +2,6 @@
 
 namespace HoomanMirghasemi\Sms\Drivers;
 
-use Exception;
 use HoomanMirghasemi\Sms\Abstracts\Driver;
 use HoomanMirghasemi\Sms\Clients\GhasedakClient;
 
@@ -14,21 +13,21 @@ class Ghasedak extends Driver
 
     public function __construct(
         protected array $settings,
-        private ?string $lineNumber = null
+        private ?string $lineNumber = null,
     ) {
-        if (!isset($this->lineNumber) && isset($this->settings['from'])) {
+        if (! isset($this->lineNumber) && isset($this->settings['from'])) {
             $this->lineNumber = $this->settings['from'];
         }
 
         $this->ghasedakClient = new GhasedakClient(
             $this->settings['base_api_url'] ?? 'https://gateway.ghasedak.me/rest/api/v1/WebService',
-            $this->settings['apiKey'] ?? ''
+            $this->settings['apiKey'] ?? '',
         );
     }
 
     public function getBalance(): string
     {
-        if (!$this->serviceActive) {
+        if (! $this->serviceActive) {
             parent::failedConnectToProvider();
 
             return '';
@@ -38,24 +37,24 @@ class Ghasedak extends Driver
             $response = $this->ghasedakClient->getAccountInformation();
 
             if ($response->failed()) {
-                throw new Exception('HTTP request failed with status: '.$response->status(), $response->status());
+                throw new \Exception('HTTP request failed with status: '.$response->status(), $response->status());
             }
 
             $accountInfo = $response->json();
 
-            if (!$accountInfo['isSuccess']) {
-                throw new Exception('Ghasedak responded with an error: '.$accountInfo['message'], $accountInfo['statusCode']);
+            if (! $accountInfo['isSuccess']) {
+                throw new \Exception('Ghasedak responded with an error: '.$accountInfo['message'], $accountInfo['statusCode']);
             }
 
             return $accountInfo['data']['credit'] ?? '';
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return 'message:'.$e->getMessage().' code: '.$e->getCode();
         }
     }
 
     public function send(): bool
     {
-        if (!$this->serviceActive) {
+        if (! $this->serviceActive) {
             parent::failedConnectToProvider();
 
             return false;
@@ -83,13 +82,13 @@ class Ghasedak extends Driver
                 );
 
                 if ($response->failed()) {
-                    throw new Exception('HTTP request failed with status: '.$response->status(), $response->status());
+                    throw new \Exception('HTTP request failed with status: '.$response->status(), $response->status());
                 }
 
                 $result = $response->json();
 
-                if (!$result['isSuccess']) {
-                    throw new Exception('Ghasedak responded with an error: '.$result['message'], $result['statusCode']);
+                if (! $result['isSuccess']) {
+                    throw new \Exception('Ghasedak responded with an error: '.$result['message'], $result['statusCode']);
                 }
 
                 $this->success = true;
@@ -99,17 +98,17 @@ class Ghasedak extends Driver
                 $response = $this->ghasedakClient->sendSingleSMS(
                     $this->lineNumber,
                     $this->recipient,
-                    $this->message->toString()
+                    $this->message->toString(),
                 );
 
                 if ($response->failed()) {
-                    throw new Exception('HTTP request failed with status: '.$response->status(), $response->status());
+                    throw new \Exception('HTTP request failed with status: '.$response->status(), $response->status());
                 }
 
                 $result = $response->json();
 
-                if (!$result['isSuccess']) {
-                    throw new Exception('Ghasedak responded with an error: '.$result['message'], $result['statusCode']);
+                if (! $result['isSuccess']) {
+                    throw new \Exception('Ghasedak responded with an error: '.$result['message'], $result['statusCode']);
                 }
 
                 $this->success = true;
@@ -118,7 +117,7 @@ class Ghasedak extends Driver
             }
 
             $this->webserviceResponse = json_encode($result);
-        } catch (Exception $exception) {
+        } catch (\Exception $exception) {
             $this->webserviceResponse = $exception->getMessage();
             $this->success = false;
         }

--- a/src/Drivers/Ghasedak.php
+++ b/src/Drivers/Ghasedak.php
@@ -2,7 +2,6 @@
 
 namespace HoomanMirghasemi\Sms\Drivers;
 
-use Exception;
 use HoomanMirghasemi\Sms\Abstracts\Driver;
 use HoomanMirghasemi\Sms\Clients\GhasedakClient;
 
@@ -14,7 +13,7 @@ class Ghasedak extends Driver
 
     public function __construct(
         protected array $settings,
-        private ?string $lineNumber = null
+        private ?string $lineNumber = null,
     ) {
         if (!isset($this->lineNumber) && isset($this->settings['from'])) {
             $this->lineNumber = $this->settings['from'];
@@ -22,7 +21,7 @@ class Ghasedak extends Driver
 
         $this->ghasedakClient = new GhasedakClient(
             $this->settings['base_api_url'] ?? 'https://gateway.ghasedak.me/rest/api/v1/WebService',
-            $this->settings['apiKey'] ?? ''
+            $this->settings['apiKey'] ?? '',
         );
     }
 
@@ -38,17 +37,17 @@ class Ghasedak extends Driver
             $response = $this->ghasedakClient->getAccountInformation();
 
             if ($response->failed()) {
-                throw new Exception('HTTP request failed with status: '.$response->status(), $response->status());
+                throw new \Exception('HTTP request failed with status: '.$response->status(), $response->status());
             }
 
             $accountInfo = $response->json();
 
             if (!$accountInfo['isSuccess']) {
-                throw new Exception('Ghasedak responded with an error: '.$accountInfo['message'], $accountInfo['statusCode']);
+                throw new \Exception('Ghasedak responded with an error: '.$accountInfo['message'], $accountInfo['statusCode']);
             }
 
             return $accountInfo['data']['credit'] ?? '';
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return 'message:'.$e->getMessage().' code: '.$e->getCode();
         }
     }
@@ -83,13 +82,13 @@ class Ghasedak extends Driver
                 );
 
                 if ($response->failed()) {
-                    throw new Exception('HTTP request failed with status: '.$response->status(), $response->status());
+                    throw new \Exception('HTTP request failed with status: '.$response->status(), $response->status());
                 }
 
                 $result = $response->json();
 
                 if (!$result['isSuccess']) {
-                    throw new Exception('Ghasedak responded with an error: '.$result['message'], $result['statusCode']);
+                    throw new \Exception('Ghasedak responded with an error: '.$result['message'], $result['statusCode']);
                 }
 
                 $this->success = true;
@@ -99,17 +98,17 @@ class Ghasedak extends Driver
                 $response = $this->ghasedakClient->sendSingleSMS(
                     $this->lineNumber,
                     $this->recipient,
-                    $this->message->toString()
+                    $this->message->toString(),
                 );
 
                 if ($response->failed()) {
-                    throw new Exception('HTTP request failed with status: '.$response->status(), $response->status());
+                    throw new \Exception('HTTP request failed with status: '.$response->status(), $response->status());
                 }
 
                 $result = $response->json();
 
                 if (!$result['isSuccess']) {
-                    throw new Exception('Ghasedak responded with an error: '.$result['message'], $result['statusCode']);
+                    throw new \Exception('Ghasedak responded with an error: '.$result['message'], $result['statusCode']);
                 }
 
                 $this->success = true;
@@ -118,7 +117,7 @@ class Ghasedak extends Driver
             }
 
             $this->webserviceResponse = json_encode($result);
-        } catch (Exception $exception) {
+        } catch (\Exception $exception) {
             $this->webserviceResponse = $exception->getMessage();
             $this->success = false;
         }

--- a/src/Drivers/Ghasedak.php
+++ b/src/Drivers/Ghasedak.php
@@ -2,38 +2,55 @@
 
 namespace HoomanMirghasemi\Sms\Drivers;
 
-use DateTimeImmutable;
 use Exception;
-use Ghasedak\DataTransferObjects\Request\OtpMessageWithParamsDTO;
-use Ghasedak\DataTransferObjects\Request\ReceptorDTO;
-use Ghasedak\DataTransferObjects\Request\SingleMessageDTO;
-use Ghasedak\GhasedaksmsApi;
 use HoomanMirghasemi\Sms\Abstracts\Driver;
+use HoomanMirghasemi\Sms\Clients\GhasedakClient;
 
 class Ghasedak extends Driver
 {
     protected string $from = '';
 
+    private GhasedakClient $ghasedakClient;
+
     public function __construct(
         protected array $settings,
-        private GhasedaksmsApi $ghasedakSmsApi,
         private ?string $lineNumber = null
     ) {
         if (!isset($this->lineNumber) && isset($this->settings['from'])) {
             $this->lineNumber = $this->settings['from'];
         }
+
+        $this->ghasedakClient = new GhasedakClient(
+            $this->settings['base_api_url'] ?? 'https://gateway.ghasedak.me/rest/api/v1/WebService',
+            $this->settings['apiKey'] ?? ''
+        );
     }
 
     public function getBalance(): string
     {
-        return '';
+        if (!$this->serviceActive) {
+            parent::failedConnectToProvider();
+            return '';
+        }
+
+        try {
+            $accountInfo = $this->ghasedakClient->getAccountInformation()->json();
+
+            if (!$accountInfo['isSuccess']) {
+                throw new Exception("Ghasedak responded with an error: " . $accountInfo['message'], $accountInfo['statusCode']);
+            }
+
+            return $accountInfo['data']['credit'] ?? '';
+
+        } catch (Exception $e) {
+            return 'message:'.$e->getMessage().' code: '.$e->getCode();
+        }
     }
 
     public function send(): bool
     {
         if (!$this->serviceActive) {
             parent::failedConnectToProvider();
-
             return false;
         }
 
@@ -43,43 +60,49 @@ class Ghasedak extends Driver
                 $identifier = $template['identifier'];
                 $params = array_values($template['params']);
 
-                $result = $this->ghasedakSmsApi->sendOtpWithParams(
-                    new OtpMessageWithParamsDTO(
-                        new DateTimeImmutable('now'),
-                        [new ReceptorDTO($this->recipient, '1')],
-                        $identifier,
-                        $params[0],
-                        $params[1] ?? null,
-                        $params[2] ?? null,
-                        $params[3] ?? null,
-                        $params[4] ?? null,
-                        $params[5] ?? null,
-                        $params[6] ?? null,
-                        $params[7] ?? null,
-                        $params[8] ?? null,
-                        $params[9] ?? null,
-                    )
+                $response = $this->ghasedakClient->sendOtpWithParams(
+                    $identifier,
+                    $this->recipient,
+                    $params[0],
+                    $params[1] ?? null,
+                    $params[2] ?? null,
+                    $params[3] ?? null,
+                    $params[4] ?? null,
+                    $params[5] ?? null,
+                    $params[6] ?? null,
+                    $params[7] ?? null,
+                    $params[8] ?? null,
+                    $params[9] ?? null,
                 );
 
-                $this->success = isset($result);
-                $this->from = '';
-                $this->message = $identifier;
+                $result = $response->json();
+
+                if (!$result['isSuccess']) {
+                    throw new Exception("Ghasedak responded with an error: " . $result['message'], $result['statusCode']);
+                }
+
+                $this->success = true;
+                $this->from = $identifier;
+                $this->message = $result['message'];
+
             } else {
-                $result = $this->ghasedakSmsApi->sendSingle(
-                    new SingleMessageDTO(
-                        new DateTimeImmutable('now'),
-                        $this->lineNumber,
-                        $this->recipient,
-                        $this->message->toString()
-                    )
+
+                $response = $this->ghasedakClient->sendSingleSMS(
+                    $this->lineNumber, $this->recipient, $this->message->toString()
                 );
 
-                $this->success = $result->getMessageId() !== null;
-                $this->from = $result->getLineNumber();
-                $this->message = $result->getMessage();
+                $result = $response->json();
+
+                if (!$result['isSuccess']) {
+                    throw new Exception("Ghasedak responded with an error: " . $result['message'], $result['statusCode']);
+                }
+
+                $this->success = true;
+                $this->from = $result['data']['lineNumber'];
+                $this->message = $result['message'];
             }
 
-            $this->webserviceResponse = print_r($result, true);
+            $this->webserviceResponse = json_encode($result);
         } catch (Exception $exception) {
             $this->webserviceResponse = $exception->getMessage();
             $this->success = false;

--- a/src/Drivers/Ghasedak.php
+++ b/src/Drivers/Ghasedak.php
@@ -34,7 +34,13 @@ class Ghasedak extends Driver
         }
 
         try {
-            $accountInfo = $this->ghasedakClient->getAccountInformation()->json();
+            $response = $this->ghasedakClient->getAccountInformation();
+
+            if ($response->failed()) {
+                throw new Exception("HTTP request failed with status: " . $response->status(), $response->status());
+            }
+
+            $accountInfo = $response->json();
 
             if (!$accountInfo['isSuccess']) {
                 throw new Exception("Ghasedak responded with an error: " . $accountInfo['message'], $accountInfo['statusCode']);
@@ -75,6 +81,10 @@ class Ghasedak extends Driver
                     $params[9] ?? null,
                 );
 
+                if ($response->failed()) {
+                    throw new Exception("HTTP request failed with status: " . $response->status(), $response->status());
+                }
+
                 $result = $response->json();
 
                 if (!$result['isSuccess']) {
@@ -90,6 +100,10 @@ class Ghasedak extends Driver
                 $response = $this->ghasedakClient->sendSingleSMS(
                     $this->lineNumber, $this->recipient, $this->message->toString()
                 );
+
+                if ($response->failed()) {
+                    throw new Exception("HTTP request failed with status: " . $response->status(), $response->status());
+                }
 
                 $result = $response->json();
 

--- a/src/Drivers/Kavenegar.php
+++ b/src/Drivers/Kavenegar.php
@@ -40,7 +40,7 @@ class Kavenegar extends Driver
                     $identifier,
                     null,
                     $token10,
-                    $token20
+                    $token20,
                 );
             } else {
                 $result = $this->kavenegarApi->Send(null, $this->recipient, $this->message->toString());

--- a/src/Drivers/Magfa.php
+++ b/src/Drivers/Magfa.php
@@ -2,16 +2,14 @@
 
 namespace HoomanMirghasemi\Sms\Drivers;
 
-use Exception;
 use HoomanMirghasemi\Sms\Abstracts\Driver;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Log;
 use SoapClient;
-use SoapFault;
 
 class Magfa extends Driver
 {
-    private SoapClient $soapClient;
+    private \SoapClient $soapClient;
 
     public function __construct(protected array $settings)
     {
@@ -23,18 +21,16 @@ class Magfa extends Driver
      * Send sms method for Magfa.
      *
      * This method send sms and save log to db.
-     *
-     * @return bool
      */
     public function send(): bool
     {
-        if (!$this->serviceActive) {
+        if (! $this->serviceActive) {
             parent::failedConnectToProvider();
 
             return false;
         }
         $response = $this->soapClient->send([$this->getMessage()], [$this->from], [$this->recipient]);
-        if ($response->status == 0) {
+        if (0 == $response->status) {
             $this->webserviceResponse = "Message has been successfully sent ; MessageId : {$response->messages->id}";
             $this->success = true;
         }
@@ -48,12 +44,10 @@ class Magfa extends Driver
 
     /**
      * Return the remaining balance of magfa.
-     *
-     * @return string
      */
     public function getBalance(): string
     {
-        if (!$this->serviceActive) {
+        if (! $this->serviceActive) {
             return 'وب سرویس مگفا با مشکل مواجه شده.';
         }
 
@@ -61,27 +55,25 @@ class Magfa extends Driver
             $response = $this->soapClient->balance();
 
             return $response->balance;
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return 'message:'.$e->getMessage().' code: '.$e->getCode();
         }
     }
 
     /**
      * Make SoapClient object and connect to magfa wsdl webservices.
-     *
-     * @return void
      */
     private function tryConnectToProvider(): void
     {
         try {
-            $this->soapClient = new SoapClient(data_get($this->settings, 'wsdl_url'), [
+            $this->soapClient = new \SoapClient(data_get($this->settings, 'wsdl_url'), [
                 'login'       => data_get($this->settings, 'username').'/'.data_get($this->settings, 'domain'),
                 'password'    => data_get($this->settings, 'password'),
                 'cache_wsdl'  => WSDL_CACHE_NONE, // -No WSDL Cache
                 'compression' => (SOAP_COMPRESSION_ACCEPT | SOAP_COMPRESSION_GZIP | 5), // -Compression *
                 'trace'       => App::environment(['local', 'staging', 'testing']), // -Optional (debug)
             ]);
-        } catch (SoapFault $soapFault) {
+        } catch (\SoapFault $soapFault) {
             Log::error('magfa sms code: '.$soapFault->getCode().' message: '.$soapFault->getMessage());
             $this->serviceActive = false;
         }
@@ -89,8 +81,6 @@ class Magfa extends Driver
 
     /**
      * Return error messages for SmsMagfa.
-     *
-     * @return array
      */
     private function getErrors(): array
     {

--- a/src/Drivers/Magfa.php
+++ b/src/Drivers/Magfa.php
@@ -24,7 +24,7 @@ class Magfa extends Driver
      */
     public function send(): bool
     {
-        if (! $this->serviceActive) {
+        if (!$this->serviceActive) {
             parent::failedConnectToProvider();
 
             return false;
@@ -47,7 +47,7 @@ class Magfa extends Driver
      */
     public function getBalance(): string
     {
-        if (! $this->serviceActive) {
+        if (!$this->serviceActive) {
             return 'وب سرویس مگفا با مشکل مواجه شده.';
         }
 

--- a/src/Drivers/Magfa.php
+++ b/src/Drivers/Magfa.php
@@ -2,16 +2,14 @@
 
 namespace HoomanMirghasemi\Sms\Drivers;
 
-use Exception;
 use HoomanMirghasemi\Sms\Abstracts\Driver;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Log;
 use SoapClient;
-use SoapFault;
 
 class Magfa extends Driver
 {
-    private SoapClient $soapClient;
+    private \SoapClient $soapClient;
 
     public function __construct(protected array $settings)
     {
@@ -23,8 +21,6 @@ class Magfa extends Driver
      * Send sms method for Magfa.
      *
      * This method send sms and save log to db.
-     *
-     * @return bool
      */
     public function send(): bool
     {
@@ -34,7 +30,7 @@ class Magfa extends Driver
             return false;
         }
         $response = $this->soapClient->send([$this->getMessage()], [$this->from], [$this->recipient]);
-        if ($response->status == 0) {
+        if (0 == $response->status) {
             $this->webserviceResponse = "Message has been successfully sent ; MessageId : {$response->messages->id}";
             $this->success = true;
         }
@@ -48,8 +44,6 @@ class Magfa extends Driver
 
     /**
      * Return the remaining balance of magfa.
-     *
-     * @return string
      */
     public function getBalance(): string
     {
@@ -61,27 +55,25 @@ class Magfa extends Driver
             $response = $this->soapClient->balance();
 
             return $response->balance;
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return 'message:'.$e->getMessage().' code: '.$e->getCode();
         }
     }
 
     /**
      * Make SoapClient object and connect to magfa wsdl webservices.
-     *
-     * @return void
      */
     private function tryConnectToProvider(): void
     {
         try {
-            $this->soapClient = new SoapClient(data_get($this->settings, 'wsdl_url'), [
+            $this->soapClient = new \SoapClient(data_get($this->settings, 'wsdl_url'), [
                 'login'       => data_get($this->settings, 'username').'/'.data_get($this->settings, 'domain'),
                 'password'    => data_get($this->settings, 'password'),
                 'cache_wsdl'  => WSDL_CACHE_NONE, // -No WSDL Cache
                 'compression' => (SOAP_COMPRESSION_ACCEPT | SOAP_COMPRESSION_GZIP | 5), // -Compression *
                 'trace'       => App::environment(['local', 'staging', 'testing']), // -Optional (debug)
             ]);
-        } catch (SoapFault $soapFault) {
+        } catch (\SoapFault $soapFault) {
             Log::error('magfa sms code: '.$soapFault->getCode().' message: '.$soapFault->getMessage());
             $this->serviceActive = false;
         }
@@ -89,8 +81,6 @@ class Magfa extends Driver
 
     /**
      * Return error messages for SmsMagfa.
-     *
-     * @return array
      */
     private function getErrors(): array
     {

--- a/src/Drivers/SmsOnline.php
+++ b/src/Drivers/SmsOnline.php
@@ -2,14 +2,13 @@
 
 namespace HoomanMirghasemi\Sms\Drivers;
 
-use Exception;
 use HoomanMirghasemi\Sms\Abstracts\Driver;
 use Illuminate\Support\Facades\Log;
 use SoapClient;
 
 class SmsOnline extends Driver
 {
-    private SoapClient $soapClient;
+    private \SoapClient $soapClient;
 
     public function __construct(protected array $settings)
     {
@@ -21,12 +20,10 @@ class SmsOnline extends Driver
      * Send sms method for OnlineSms.
      *
      * This method send sms and save log to db.
-     *
-     * @return bool
      */
     public function send(): bool
     {
-        if (!$this->serviceActive) {
+        if (! $this->serviceActive) {
             parent::failedConnectToProvider();
 
             return false;
@@ -42,7 +39,7 @@ class SmsOnline extends Driver
             'recId'    => [0],
             'status'   => [0],
         ]);
-        if ($response->SendSmsResult != 1) {
+        if (1 != $response->SendSmsResult) {
             $this->webserviceResponse = 'An error occured';
             $this->webserviceResponse .= 'Error Code : '.$this->getErrors()[$response->SendSmsResult];
             $this->success = false;
@@ -56,12 +53,10 @@ class SmsOnline extends Driver
 
     /**
      * Return the remaining balance of smsonline.
-     *
-     * @return string
      */
     public function getBalance(): string
     {
-        if (!$this->serviceActive) {
+        if (! $this->serviceActive) {
             return 'ماژول پیامک آنلاین اس ام اس برنامه غیر فعال می باشد.';
         }
 
@@ -72,15 +67,13 @@ class SmsOnline extends Driver
             ]);
 
             return (int) ceil($getCreditResult->GetCreditResult);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return 'message:'.$e->getMessage().' code: '.$e->getCode();
         }
     }
 
     /**
      * Return error messages for SmsMagfa.
-     *
-     * @return array
      */
     private function getErrors(): array
     {
@@ -102,13 +95,11 @@ class SmsOnline extends Driver
 
     /**
      * Make SoapClient object and connect to magfa wsdl webservices.
-     *
-     * @return void
      */
     private function tryConnectToProvider(): void
     {
         try {
-            $this->soapClient = new SoapClient(data_get($this->settings, 'wsdl_url'));
+            $this->soapClient = new \SoapClient(data_get($this->settings, 'wsdl_url'));
         } catch (\SoapFault $soapFault) {
             Log::error('onlinesms sms code: '.$soapFault->getCode().' message: '.$soapFault->getMessage());
             $this->serviceActive = false;

--- a/src/Drivers/SmsOnline.php
+++ b/src/Drivers/SmsOnline.php
@@ -2,14 +2,13 @@
 
 namespace HoomanMirghasemi\Sms\Drivers;
 
-use Exception;
 use HoomanMirghasemi\Sms\Abstracts\Driver;
 use Illuminate\Support\Facades\Log;
 use SoapClient;
 
 class SmsOnline extends Driver
 {
-    private SoapClient $soapClient;
+    private \SoapClient $soapClient;
 
     public function __construct(protected array $settings)
     {
@@ -21,8 +20,6 @@ class SmsOnline extends Driver
      * Send sms method for OnlineSms.
      *
      * This method send sms and save log to db.
-     *
-     * @return bool
      */
     public function send(): bool
     {
@@ -42,7 +39,7 @@ class SmsOnline extends Driver
             'recId'    => [0],
             'status'   => [0],
         ]);
-        if ($response->SendSmsResult != 1) {
+        if (1 != $response->SendSmsResult) {
             $this->webserviceResponse = 'An error occured';
             $this->webserviceResponse .= 'Error Code : '.$this->getErrors()[$response->SendSmsResult];
             $this->success = false;
@@ -56,8 +53,6 @@ class SmsOnline extends Driver
 
     /**
      * Return the remaining balance of smsonline.
-     *
-     * @return string
      */
     public function getBalance(): string
     {
@@ -72,15 +67,13 @@ class SmsOnline extends Driver
             ]);
 
             return (int) ceil($getCreditResult->GetCreditResult);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return 'message:'.$e->getMessage().' code: '.$e->getCode();
         }
     }
 
     /**
      * Return error messages for SmsMagfa.
-     *
-     * @return array
      */
     private function getErrors(): array
     {
@@ -102,13 +95,11 @@ class SmsOnline extends Driver
 
     /**
      * Make SoapClient object and connect to magfa wsdl webservices.
-     *
-     * @return void
      */
     private function tryConnectToProvider(): void
     {
         try {
-            $this->soapClient = new SoapClient(data_get($this->settings, 'wsdl_url'));
+            $this->soapClient = new \SoapClient(data_get($this->settings, 'wsdl_url'));
         } catch (\SoapFault $soapFault) {
             Log::error('onlinesms sms code: '.$soapFault->getCode().' message: '.$soapFault->getMessage());
             $this->serviceActive = false;

--- a/src/Drivers/SmsOnline.php
+++ b/src/Drivers/SmsOnline.php
@@ -23,7 +23,7 @@ class SmsOnline extends Driver
      */
     public function send(): bool
     {
-        if (! $this->serviceActive) {
+        if (!$this->serviceActive) {
             parent::failedConnectToProvider();
 
             return false;
@@ -56,7 +56,7 @@ class SmsOnline extends Driver
      */
     public function getBalance(): string
     {
-        if (! $this->serviceActive) {
+        if (!$this->serviceActive) {
             return 'ماژول پیامک آنلاین اس ام اس برنامه غیر فعال می باشد.';
         }
 

--- a/src/Exceptions/DriverNotFoundException.php
+++ b/src/Exceptions/DriverNotFoundException.php
@@ -2,8 +2,6 @@
 
 namespace HoomanMirghasemi\Sms\Exceptions;
 
-use Exception;
-
-class DriverNotFoundException extends Exception
+class DriverNotFoundException extends \Exception
 {
 }

--- a/src/Exceptions/InvalidMessageException.php
+++ b/src/Exceptions/InvalidMessageException.php
@@ -2,8 +2,6 @@
 
 namespace HoomanMirghasemi\Sms\Exceptions;
 
-use Exception;
-
-class InvalidMessageException extends Exception
+class InvalidMessageException extends \Exception
 {
 }

--- a/src/Http/Controllers/Web/SmsController.php
+++ b/src/Http/Controllers/Web/SmsController.php
@@ -14,12 +14,10 @@ class SmsController extends Controller
     /**
      * Show sms in paginated list.
      * This page only use for develop.
-     *
-     * @return Factory|View|Application
      */
     public function index(): Factory|View|Application
     {
-        /**
+        /*
          * Action information.
          *
          * @get(/sms/get-sms-list)

--- a/src/Listeners/DbLogListener.php
+++ b/src/Listeners/DbLogListener.php
@@ -12,8 +12,6 @@ class DbLogListener
      * Handle the event.
      *
      * @param object $event
-     *
-     * @return void
      */
     public function handle(SmsEvent $event): void
     {
@@ -22,8 +20,6 @@ class DbLogListener
 
     /**
      * This method should call in all driver send method in last line.
-     *
-     * @return void
      */
     protected function saveLogInDb(Driver $smsDriver): void
     {

--- a/src/Message.php
+++ b/src/Message.php
@@ -53,7 +53,7 @@ class Message implements MessageContract
      */
     public function usesTemplate(): bool
     {
-        return ! is_null($this->template['identifier']);
+        return !is_null($this->template['identifier']);
     }
 
     /**

--- a/src/Message.php
+++ b/src/Message.php
@@ -15,8 +15,6 @@ class Message implements MessageContract
 
     /**
      * Template options.
-     *
-     * @var array
      */
     protected array $template = [
         'identifier' => null,
@@ -25,8 +23,6 @@ class Message implements MessageContract
 
     /**
      * Message constructor.
-     *
-     * @param string $message
      */
     public function __construct(string $message)
     {
@@ -35,8 +31,6 @@ class Message implements MessageContract
 
     /**
      * Retrieve string format of message.
-     *
-     * @return string
      */
     public function toString(): string
     {
@@ -45,11 +39,6 @@ class Message implements MessageContract
 
     /**
      * Retrieve string format of message.
-     *
-     * @param string $templateIdentifier
-     * @param array  $params
-     *
-     * @return self
      */
     public function useTemplateIfSupports(string $templateIdentifier, array $params = []): self
     {
@@ -64,13 +53,11 @@ class Message implements MessageContract
      */
     public function usesTemplate(): bool
     {
-        return !is_null($this->template['identifier']);
+        return ! is_null($this->template['identifier']);
     }
 
     /**
      * Retrieve template options.
-     *
-     * @return array
      */
     public function getTemplate(): array
     {

--- a/src/Message.php
+++ b/src/Message.php
@@ -15,8 +15,6 @@ class Message implements MessageContract
 
     /**
      * Template options.
-     *
-     * @var array
      */
     protected array $template = [
         'identifier' => null,
@@ -25,8 +23,6 @@ class Message implements MessageContract
 
     /**
      * Message constructor.
-     *
-     * @param string $message
      */
     public function __construct(string $message)
     {
@@ -35,8 +31,6 @@ class Message implements MessageContract
 
     /**
      * Retrieve string format of message.
-     *
-     * @return string
      */
     public function toString(): string
     {
@@ -45,11 +39,6 @@ class Message implements MessageContract
 
     /**
      * Retrieve string format of message.
-     *
-     * @param string $templateIdentifier
-     * @param array  $params
-     *
-     * @return self
      */
     public function useTemplateIfSupports(string $templateIdentifier, array $params = []): self
     {
@@ -69,8 +58,6 @@ class Message implements MessageContract
 
     /**
      * Retrieve template options.
-     *
-     * @return array
      */
     public function getTemplate(): array
     {

--- a/src/Providers/SmsProvider.php
+++ b/src/Providers/SmsProvider.php
@@ -66,21 +66,16 @@ class SmsProvider extends ServiceProvider
             return new Avanak($config);
         });
 
+        $this->app->bind(Ghasedak::class, function () {
+            return new Ghasedak(config('sms.drivers.ghasedak') ?? []);
+        });
+
         if (class_exists(\Kavenegar\KavenegarApi::class)) {
             $this->app->bind(Kavenegar::class, function () {
                 $config = config('sms.drivers.kavenegar') ?? [];
                 $kavenegarApi = new \Kavenegar\KavenegarApi($config['apiKey']);
 
                 return new Kavenegar($config, $kavenegarApi);
-            });
-        }
-
-        if (class_exists(\Ghasedak\GhasedaksmsApi::class)) {
-            $this->app->bind(Ghasedak::class, function () {
-                $config = config('sms.drivers.ghasedak') ?? [];
-                $ghasedakApi = new \Ghasedak\GhasedaksmsApi($config['apiKey']);
-
-                return new Ghasedak($config, $ghasedakApi);
             });
         }
     }

--- a/src/Providers/SmsProvider.php
+++ b/src/Providers/SmsProvider.php
@@ -16,8 +16,6 @@ class SmsProvider extends ServiceProvider
 {
     /**
      * Boot the application events.
-     *
-     * @return void
      */
     public function boot(): void
     {
@@ -26,8 +24,6 @@ class SmsProvider extends ServiceProvider
 
     /**
      * Register the service provider.
-     *
-     * @return void
      */
     public function register(): void
     {
@@ -36,7 +32,7 @@ class SmsProvider extends ServiceProvider
         $this->app->register(RouteServiceProvider::class);
         $this->app->register(EventServiceProvider::class);
 
-        /**
+        /*
          * Bind to service container.
          */
         $this->app->singleton('sms', SmsManager::class);
@@ -109,7 +105,7 @@ class SmsProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(
             __DIR__.'/../../config/sms.php',
-            'sms'
+            'sms',
         );
 
         $this->publishes([

--- a/src/SmsManager.php
+++ b/src/SmsManager.php
@@ -14,8 +14,6 @@ class SmsManager extends Manager
 {
     /**
      * Create an instance of the nexmo sms sender driver.
-     *
-     * @return Kavenegar
      */
     protected function createKavenegarDriver(): Kavenegar
     {
@@ -24,8 +22,6 @@ class SmsManager extends Manager
 
     /**
      * Create an instance of the fake sms sender driver.
-     *
-     * @return FakeSmsSender
      */
     protected function createFakeDriver(): FakeSmsSender
     {
@@ -54,8 +50,6 @@ class SmsManager extends Manager
 
     /**
      * Create an instance of the ghasedak sms sender driver.
-     *
-     * @return Ghasedak
      */
     protected function createGhasedakDriver(): Ghasedak
     {
@@ -64,8 +58,6 @@ class SmsManager extends Manager
 
     /**
      * Get the default sms driver name.
-     *
-     * @return string
      */
     public function getDefaultDriver(): string
     {
@@ -78,10 +70,6 @@ class SmsManager extends Manager
 
     /**
      * Set the default sms driver name.
-     *
-     * @param string $name
-     *
-     * @return void
      */
     public function setDefaultDriver(string $name): void
     {

--- a/src/VoiceCallManager.php
+++ b/src/VoiceCallManager.php
@@ -11,8 +11,6 @@ class VoiceCallManager extends Manager
 {
     /**
      * Create an instance of the avanak voice call sender driver.
-     *
-     * @return Avanak
      */
     protected function createAvanakDriver(): Avanak
     {
@@ -21,8 +19,6 @@ class VoiceCallManager extends Manager
 
     /**
      * Create an instance of the fake voice call sender driver.
-     *
-     * @return FakeSmsSender
      */
     protected function createFakeDriver(): FakeSmsSender
     {
@@ -31,8 +27,6 @@ class VoiceCallManager extends Manager
 
     /**
      * Get the default voice call driver name.
-     *
-     * @return string
      */
     public function getDefaultDriver(): string
     {
@@ -47,8 +41,6 @@ class VoiceCallManager extends Manager
      * Set the default sms driver name.
      *
      * @param string $name
-     *
-     * @return void
      */
     public function setDefaultDriver($name): void
     {

--- a/tests/Feature/Drivers/GhasedakTest.php
+++ b/tests/Feature/Drivers/GhasedakTest.php
@@ -106,7 +106,7 @@ class GhasedakTest extends TestCase
 
         $this->assertFalse($result);
         $this->assertFalse($ghasedak->getResult());
-        $this->assertStringContainsString('Invalid API key', $ghasedak->getWebServiceResponce());
+        $this->assertStringContainsString('HTTP request failed with status: 401', $ghasedak->getWebServiceResponce());
 
         Event::assertDispatched(SmsSentEvent::class);
     }
@@ -189,7 +189,7 @@ class GhasedakTest extends TestCase
         $ghasedak = new Ghasedak($this->config);
         $balance = $ghasedak->getBalance();
 
-        $this->assertStringContainsString('Unauthorized', $balance);
+        $this->assertStringContainsString('HTTP request failed with status: 401', $balance);
         $this->assertStringContainsString('message:', $balance);
     }
 
@@ -351,7 +351,7 @@ class GhasedakTest extends TestCase
             ->send();
 
         $this->assertFalse($result);
-        $this->assertStringContainsString('Invalid template', $ghasedak->getWebServiceResponce());
+        $this->assertStringContainsString('HTTP request failed with status: 400', $ghasedak->getWebServiceResponce());
     }
 
     public function testSendOtpTemplateFailureWithSuccessfulHttpButFailedResponse()

--- a/tests/Feature/Drivers/GhasedakTest.php
+++ b/tests/Feature/Drivers/GhasedakTest.php
@@ -3,12 +3,12 @@
 namespace HoomanMirghasemi\Sms\Tests\Feature\Drivers;
 
 use HoomanMirghasemi\Sms\Drivers\Ghasedak;
+use HoomanMirghasemi\Sms\Events\ProviderConnectionFailedEvent;
+use HoomanMirghasemi\Sms\Events\SmsSentEvent;
 use HoomanMirghasemi\Sms\Message;
 use HoomanMirghasemi\Sms\Tests\TestCase;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Event;
-use HoomanMirghasemi\Sms\Events\SmsSentEvent;
-use HoomanMirghasemi\Sms\Events\ProviderConnectionFailedEvent;
+use Illuminate\Support\Facades\Http;
 
 class GhasedakTest extends TestCase
 {
@@ -22,8 +22,8 @@ class GhasedakTest extends TestCase
 
         $this->config = [
             'base_api_url' => 'https://gateway.ghasedak.me/rest/api/v1/WebService',
-            'apiKey' => 'test-api-key',
-            'from' => $this->lineNumber
+            'apiKey'       => 'test-api-key',
+            'from'         => $this->lineNumber,
         ];
     }
 
@@ -33,14 +33,14 @@ class GhasedakTest extends TestCase
 
         Http::fake([
             '*/SendSingleSMS' => Http::response([
-                'isSuccess' => true,
+                'isSuccess'  => true,
                 'statusCode' => 200,
-                'message' => 'Message sent successfully',
-                'data' => [
+                'message'    => 'Message sent successfully',
+                'data'       => [
                     'lineNumber' => $this->lineNumber,
-                    'messageId' => '123456789'
-                ]
-            ], 200)
+                    'messageId'  => '123456789',
+                ],
+            ], 200),
         ]);
 
         $ghasedak = new Ghasedak($this->config);
@@ -63,14 +63,14 @@ class GhasedakTest extends TestCase
 
         Http::fake([
             '*/SendOtpWithParams' => Http::response([
-                'isSuccess' => true,
+                'isSuccess'  => true,
                 'statusCode' => 200,
-                'message' => 'OTP sent successfully'
-            ], 200)
+                'message'    => 'OTP sent successfully',
+            ], 200),
         ]);
 
         $code = '233269';
-        $message = new Message('کد تایید ارسال شده ' . PHP_EOL . $code);
+        $message = new Message('کد تایید ارسال شده '.PHP_EOL.$code);
         $message->useTemplateIfSupports('SmsRegisterSuccess', [
             'token1' => $code,
         ]);
@@ -93,10 +93,10 @@ class GhasedakTest extends TestCase
 
         Http::fake([
             '*/SendSingleSMS' => Http::response([
-                'isSuccess' => false,
+                'isSuccess'  => false,
                 'statusCode' => 401,
-                'message' => 'Invalid API key'
-            ], 401)
+                'message'    => 'Invalid API key',
+            ], 401),
         ]);
 
         $ghasedak = new Ghasedak($this->config);
@@ -117,10 +117,10 @@ class GhasedakTest extends TestCase
 
         Http::fake([
             '*/SendSingleSMS' => Http::response([
-                'isSuccess' => false,
+                'isSuccess'  => false,
                 'statusCode' => 400,
-                'message' => 'Insufficient credit'
-            ], 200)
+                'message'    => 'Insufficient credit',
+            ], 200),
         ]);
 
         $ghasedak = new Ghasedak($this->config);
@@ -142,7 +142,7 @@ class GhasedakTest extends TestCase
         Http::fake([
             '*/SendSingleSMS' => function () {
                 throw new \Illuminate\Http\Client\ConnectionException('Network error');
-            }
+            },
         ]);
 
         $ghasedak = new Ghasedak($this->config);
@@ -161,13 +161,13 @@ class GhasedakTest extends TestCase
     {
         Http::fake([
             '*/GetAccountInformation' => Http::response([
-                'isSuccess' => true,
+                'isSuccess'  => true,
                 'statusCode' => 200,
-                'message' => 'Success',
-                'data' => [
-                    'credit' => '50000'
-                ]
-            ], 200)
+                'message'    => 'Success',
+                'data'       => [
+                    'credit' => '50000',
+                ],
+            ], 200),
         ]);
 
         $ghasedak = new Ghasedak($this->config);
@@ -180,10 +180,10 @@ class GhasedakTest extends TestCase
     {
         Http::fake([
             '*/GetAccountInformation' => Http::response([
-                'isSuccess' => false,
+                'isSuccess'  => false,
                 'statusCode' => 401,
-                'message' => 'Unauthorized'
-            ], 401)
+                'message'    => 'Unauthorized',
+            ], 401),
         ]);
 
         $ghasedak = new Ghasedak($this->config);
@@ -197,10 +197,10 @@ class GhasedakTest extends TestCase
     {
         Http::fake([
             '*/GetAccountInformation' => Http::response([
-                'isSuccess' => false,
+                'isSuccess'  => false,
                 'statusCode' => 403,
-                'message' => 'Access denied'
-            ], 200)
+                'message'    => 'Access denied',
+            ], 200),
         ]);
 
         $ghasedak = new Ghasedak($this->config);
@@ -216,7 +216,7 @@ class GhasedakTest extends TestCase
         Http::fake([
             '*/GetAccountInformation' => function () {
                 throw new \Illuminate\Http\Client\ConnectionException('Connection failed');
-            }
+            },
         ]);
 
         $ghasedak = new Ghasedak($this->config);
@@ -268,7 +268,7 @@ class GhasedakTest extends TestCase
     {
         $config = [
             'base_api_url' => 'https://gateway.ghasedak.me/rest/api/v1/WebService',
-            'apiKey' => 'test-api-key'
+            'apiKey'       => 'test-api-key',
         ];
 
         $ghasedak = new Ghasedak($config);
@@ -299,17 +299,17 @@ class GhasedakTest extends TestCase
 
         Http::fake([
             '*/SendOtpWithParams' => Http::response([
-                'isSuccess' => true,
+                'isSuccess'  => true,
                 'statusCode' => 200,
-                'message' => 'OTP sent successfully'
-            ], 200)
+                'message'    => 'OTP sent successfully',
+            ], 200),
         ]);
 
         $message = new Message('Test message');
         $message->useTemplateIfSupports('OrderTemplate', [
             'token1' => 'John',
             'token2' => '5000',
-            'token3' => 'Order#123'
+            'token3' => 'Order#123',
         ]);
 
         $ghasedak = new Ghasedak($this->config);
@@ -321,10 +321,11 @@ class GhasedakTest extends TestCase
 
         Http::assertSent(function ($request) {
             $body = $request->data();
-            return $body['templateName'] === 'OrderTemplate' &&
-                   $body['param1'] === 'John' &&
-                   $body['param2'] === '5000' &&
-                   $body['param3'] === 'Order#123';
+
+            return 'OrderTemplate' === $body['templateName']
+                   && 'John' === $body['param1']
+                   && '5000' === $body['param2']
+                   && 'Order#123' === $body['param3'];
         });
     }
 
@@ -334,10 +335,10 @@ class GhasedakTest extends TestCase
 
         Http::fake([
             '*/SendOtpWithParams' => Http::response([
-                'isSuccess' => false,
+                'isSuccess'  => false,
                 'statusCode' => 400,
-                'message' => 'Invalid template'
-            ], 400)
+                'message'    => 'Invalid template',
+            ], 400),
         ]);
 
         $message = new Message('Code: 123456');
@@ -360,10 +361,10 @@ class GhasedakTest extends TestCase
 
         Http::fake([
             '*/SendOtpWithParams' => Http::response([
-                'isSuccess' => false,
+                'isSuccess'  => false,
                 'statusCode' => 404,
-                'message' => 'Template not found'
-            ], 200)
+                'message'    => 'Template not found',
+            ], 200),
         ]);
 
         $message = new Message('Code: 123456');
@@ -387,20 +388,20 @@ class GhasedakTest extends TestCase
     {
         $customConfig = [
             'base_api_url' => 'https://custom-api.example.com/api/v1',
-            'apiKey' => 'custom-key',
-            'from' => $this->lineNumber
+            'apiKey'       => 'custom-key',
+            'from'         => $this->lineNumber,
         ];
 
         Http::fake([
             'https://custom-api.example.com/api/v1/SendSingleSMS' => Http::response([
-                'isSuccess' => true,
+                'isSuccess'  => true,
                 'statusCode' => 200,
-                'message' => 'Success',
-                'data' => [
+                'message'    => 'Success',
+                'data'       => [
                     'lineNumber' => $this->lineNumber,
-                    'messageId' => '999'
-                ]
-            ], 200)
+                    'messageId'  => '999',
+                ],
+            ], 200),
         ]);
 
         $ghasedak = new Ghasedak($customConfig);

--- a/tests/Feature/Drivers/GhasedakTest.php
+++ b/tests/Feature/Drivers/GhasedakTest.php
@@ -5,48 +5,413 @@ namespace HoomanMirghasemi\Sms\Tests\Feature\Drivers;
 use HoomanMirghasemi\Sms\Drivers\Ghasedak;
 use HoomanMirghasemi\Sms\Message;
 use HoomanMirghasemi\Sms\Tests\TestCase;
-use Mockery\MockInterface;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Event;
+use HoomanMirghasemi\Sms\Events\SmsSentEvent;
+use HoomanMirghasemi\Sms\Events\ProviderConnectionFailedEvent;
 
 class GhasedakTest extends TestCase
 {
-    private string $mobile = '+98935123456';
+    private string $mobile = '09351234567';
+    private string $lineNumber = '30005088';
+    private array $config;
 
-    public function testSuccessSend()
+    protected function setUp(): void
     {
-        /** @var Ghasedak $ghasedakStub */
-        $ghasedakStub = $this->partialMock(Ghasedak::class, function (MockInterface $mock) {
-            $mock->shouldReceive('send')
-                ->once()
-                ->andReturnTrue();
-        });
+        parent::setUp();
 
-        $result = $ghasedakStub->to($this->mobile)
+        $this->config = [
+            'base_api_url' => 'https://gateway.ghasedak.me/rest/api/v1/WebService',
+            'apiKey' => 'test-api-key',
+            'from' => $this->lineNumber
+        ];
+    }
+
+    public function testSuccessSendSingleSMS()
+    {
+        Event::fake();
+
+        Http::fake([
+            '*/SendSingleSMS' => Http::response([
+                'isSuccess' => true,
+                'statusCode' => 200,
+                'message' => 'Message sent successfully',
+                'data' => [
+                    'lineNumber' => $this->lineNumber,
+                    'messageId' => '123456789'
+                ]
+            ], 200)
+        ]);
+
+        $ghasedak = new Ghasedak($this->config);
+        $result = $ghasedak->to($this->mobile)
             ->message('Test ghasedak sms')
             ->send();
 
         $this->assertTrue($result);
+        $this->assertEquals($this->lineNumber, $ghasedak->getSenderNumber());
+        $this->assertEquals($this->mobile, $ghasedak->getRecipient());
+        $this->assertTrue($ghasedak->getResult());
+        $this->assertStringContainsString('Message sent successfully', $ghasedak->getWebServiceResponce());
+
+        Event::assertDispatched(SmsSentEvent::class);
     }
 
     public function testSuccessSendWithMessageTemplate()
     {
-        /** @var Ghasedak $ghasedakStub */
-        $ghasedakStub = $this->partialMock(Ghasedak::class, function (MockInterface $mock) {
-            $mock->shouldReceive('send')
-                ->once()
-                ->andReturnTrue();
-        });
+        Event::fake();
+
+        Http::fake([
+            '*/SendOtpWithParams' => Http::response([
+                'isSuccess' => true,
+                'statusCode' => 200,
+                'message' => 'OTP sent successfully'
+            ], 200)
+        ]);
 
         $code = '233269';
-        $message = 'کد تایید ارسال شده ';
-        $message = new Message($message.PHP_EOL.$code);
+        $message = new Message('کد تایید ارسال شده ' . PHP_EOL . $code);
         $message->useTemplateIfSupports('SmsRegisterSuccess', [
             'token1' => $code,
         ]);
 
-        $result = $ghasedakStub->to($this->mobile)
+        $ghasedak = new Ghasedak($this->config);
+        $result = $ghasedak->to($this->mobile)
             ->message($message)
             ->send();
 
         $this->assertTrue($result);
+        $this->assertEquals('SmsRegisterSuccess', $ghasedak->getSenderNumber());
+        $this->assertTrue($ghasedak->getResult());
+
+        Event::assertDispatched(SmsSentEvent::class);
+    }
+
+    public function testSendFailureInvalidApiKey()
+    {
+        Event::fake();
+
+        Http::fake([
+            '*/SendSingleSMS' => Http::response([
+                'isSuccess' => false,
+                'statusCode' => 401,
+                'message' => 'Invalid API key'
+            ], 401)
+        ]);
+
+        $ghasedak = new Ghasedak($this->config);
+        $result = $ghasedak->to($this->mobile)
+            ->message('Test message')
+            ->send();
+
+        $this->assertFalse($result);
+        $this->assertFalse($ghasedak->getResult());
+        $this->assertStringContainsString('Invalid API key', $ghasedak->getWebServiceResponce());
+
+        Event::assertDispatched(SmsSentEvent::class);
+    }
+
+    public function testSendSingleSMSFailureWithSuccessfulHttpButFailedResponse()
+    {
+        Event::fake();
+
+        Http::fake([
+            '*/SendSingleSMS' => Http::response([
+                'isSuccess' => false,
+                'statusCode' => 400,
+                'message' => 'Insufficient credit'
+            ], 200)
+        ]);
+
+        $ghasedak = new Ghasedak($this->config);
+        $result = $ghasedak->to($this->mobile)
+            ->message('Test message')
+            ->send();
+
+        $this->assertFalse($result);
+        $this->assertFalse($ghasedak->getResult());
+        $this->assertStringContainsString('Insufficient credit', $ghasedak->getWebServiceResponce());
+
+        Event::assertDispatched(SmsSentEvent::class);
+    }
+
+    public function testSendFailureNetworkError()
+    {
+        Event::fake();
+
+        Http::fake([
+            '*/SendSingleSMS' => function () {
+                throw new \Illuminate\Http\Client\ConnectionException('Network error');
+            }
+        ]);
+
+        $ghasedak = new Ghasedak($this->config);
+        $result = $ghasedak->to($this->mobile)
+            ->message('Test message')
+            ->send();
+
+        $this->assertFalse($result);
+        $this->assertFalse($ghasedak->getResult());
+        $this->assertStringContainsString('Network error', $ghasedak->getWebServiceResponce());
+
+        Event::assertDispatched(SmsSentEvent::class);
+    }
+
+    public function testGetBalanceSuccess()
+    {
+        Http::fake([
+            '*/GetAccountInformation' => Http::response([
+                'isSuccess' => true,
+                'statusCode' => 200,
+                'message' => 'Success',
+                'data' => [
+                    'credit' => '50000'
+                ]
+            ], 200)
+        ]);
+
+        $ghasedak = new Ghasedak($this->config);
+        $balance = $ghasedak->getBalance();
+
+        $this->assertEquals('50000', $balance);
+    }
+
+    public function testGetBalanceFailure()
+    {
+        Http::fake([
+            '*/GetAccountInformation' => Http::response([
+                'isSuccess' => false,
+                'statusCode' => 401,
+                'message' => 'Unauthorized'
+            ], 401)
+        ]);
+
+        $ghasedak = new Ghasedak($this->config);
+        $balance = $ghasedak->getBalance();
+
+        $this->assertStringContainsString('Unauthorized', $balance);
+        $this->assertStringContainsString('message:', $balance);
+    }
+
+    public function testGetBalanceFailureWithSuccessfulHttpButFailedResponse()
+    {
+        Http::fake([
+            '*/GetAccountInformation' => Http::response([
+                'isSuccess' => false,
+                'statusCode' => 403,
+                'message' => 'Access denied'
+            ], 200)
+        ]);
+
+        $ghasedak = new Ghasedak($this->config);
+        $balance = $ghasedak->getBalance();
+
+        $this->assertStringContainsString('Access denied', $balance);
+        $this->assertStringContainsString('message:', $balance);
+        $this->assertStringContainsString('code:', $balance);
+    }
+
+    public function testGetBalanceNetworkError()
+    {
+        Http::fake([
+            '*/GetAccountInformation' => function () {
+                throw new \Illuminate\Http\Client\ConnectionException('Connection failed');
+            }
+        ]);
+
+        $ghasedak = new Ghasedak($this->config);
+        $balance = $ghasedak->getBalance();
+
+        $this->assertStringContainsString('Connection failed', $balance);
+        $this->assertStringContainsString('message:', $balance);
+    }
+
+    public function testGetBalanceWhenServiceInactive()
+    {
+        Event::fake();
+
+        $ghasedak = new Ghasedak($this->config);
+
+        // Use reflection to set serviceActive to false
+        $reflection = new \ReflectionClass($ghasedak);
+        $property = $reflection->getProperty('serviceActive');
+        $property->setAccessible(true);
+        $property->setValue($ghasedak, false);
+
+        $balance = $ghasedak->getBalance();
+
+        $this->assertEquals('', $balance);
+        Event::assertDispatched(ProviderConnectionFailedEvent::class);
+    }
+
+    public function testSendWhenServiceInactive()
+    {
+        Event::fake();
+
+        $ghasedak = new Ghasedak($this->config);
+
+        // Use reflection to set serviceActive to false
+        $reflection = new \ReflectionClass($ghasedak);
+        $property = $reflection->getProperty('serviceActive');
+        $property->setAccessible(true);
+        $property->setValue($ghasedak, false);
+
+        $result = $ghasedak->to($this->mobile)
+            ->message('Test')
+            ->send();
+
+        $this->assertFalse($result);
+        Event::assertDispatched(ProviderConnectionFailedEvent::class);
+    }
+
+    public function testConstructorWithoutLineNumber()
+    {
+        $config = [
+            'base_api_url' => 'https://gateway.ghasedak.me/rest/api/v1/WebService',
+            'apiKey' => 'test-api-key'
+        ];
+
+        $ghasedak = new Ghasedak($config);
+
+        // LineNumber should be null when not provided
+        $reflection = new \ReflectionClass($ghasedak);
+        $property = $reflection->getProperty('lineNumber');
+        $property->setAccessible(true);
+
+        $this->assertNull($property->getValue($ghasedak));
+    }
+
+    public function testConstructorWithExplicitLineNumber()
+    {
+        $customLineNumber = '30001234';
+        $ghasedak = new Ghasedak($this->config, $customLineNumber);
+
+        $reflection = new \ReflectionClass($ghasedak);
+        $property = $reflection->getProperty('lineNumber');
+        $property->setAccessible(true);
+
+        $this->assertEquals($customLineNumber, $property->getValue($ghasedak));
+    }
+
+    public function testSendWithMultipleTemplateParams()
+    {
+        Event::fake();
+
+        Http::fake([
+            '*/SendOtpWithParams' => Http::response([
+                'isSuccess' => true,
+                'statusCode' => 200,
+                'message' => 'OTP sent successfully'
+            ], 200)
+        ]);
+
+        $message = new Message('Test message');
+        $message->useTemplateIfSupports('OrderTemplate', [
+            'token1' => 'John',
+            'token2' => '5000',
+            'token3' => 'Order#123'
+        ]);
+
+        $ghasedak = new Ghasedak($this->config);
+        $result = $ghasedak->to($this->mobile)
+            ->message($message)
+            ->send();
+
+        $this->assertTrue($result);
+
+        Http::assertSent(function ($request) {
+            $body = $request->data();
+            return $body['templateName'] === 'OrderTemplate' &&
+                   $body['param1'] === 'John' &&
+                   $body['param2'] === '5000' &&
+                   $body['param3'] === 'Order#123';
+        });
+    }
+
+    public function testSendOtpTemplateFailure()
+    {
+        Event::fake();
+
+        Http::fake([
+            '*/SendOtpWithParams' => Http::response([
+                'isSuccess' => false,
+                'statusCode' => 400,
+                'message' => 'Invalid template'
+            ], 400)
+        ]);
+
+        $message = new Message('Code: 123456');
+        $message->useTemplateIfSupports('InvalidTemplate', [
+            'token1' => '123456',
+        ]);
+
+        $ghasedak = new Ghasedak($this->config);
+        $result = $ghasedak->to($this->mobile)
+            ->message($message)
+            ->send();
+
+        $this->assertFalse($result);
+        $this->assertStringContainsString('Invalid template', $ghasedak->getWebServiceResponce());
+    }
+
+    public function testSendOtpTemplateFailureWithSuccessfulHttpButFailedResponse()
+    {
+        Event::fake();
+
+        Http::fake([
+            '*/SendOtpWithParams' => Http::response([
+                'isSuccess' => false,
+                'statusCode' => 404,
+                'message' => 'Template not found'
+            ], 200)
+        ]);
+
+        $message = new Message('Code: 123456');
+        $message->useTemplateIfSupports('NonExistentTemplate', [
+            'token1' => '123456',
+        ]);
+
+        $ghasedak = new Ghasedak($this->config);
+        $result = $ghasedak->to($this->mobile)
+            ->message($message)
+            ->send();
+
+        $this->assertFalse($result);
+        $this->assertFalse($ghasedak->getResult());
+        $this->assertStringContainsString('Template not found', $ghasedak->getWebServiceResponce());
+
+        Event::assertDispatched(SmsSentEvent::class);
+    }
+
+    public function testCustomBaseApiUrl()
+    {
+        $customConfig = [
+            'base_api_url' => 'https://custom-api.example.com/api/v1',
+            'apiKey' => 'custom-key',
+            'from' => $this->lineNumber
+        ];
+
+        Http::fake([
+            'https://custom-api.example.com/api/v1/SendSingleSMS' => Http::response([
+                'isSuccess' => true,
+                'statusCode' => 200,
+                'message' => 'Success',
+                'data' => [
+                    'lineNumber' => $this->lineNumber,
+                    'messageId' => '999'
+                ]
+            ], 200)
+        ]);
+
+        $ghasedak = new Ghasedak($customConfig);
+        $result = $ghasedak->to($this->mobile)
+            ->message('Test')
+            ->send();
+
+        $this->assertTrue($result);
+
+        Http::assertSent(function ($request) {
+            return str_contains($request->url(), 'custom-api.example.com');
+        });
     }
 }

--- a/tests/Unit/Clients/GhasedakClientTest.php
+++ b/tests/Unit/Clients/GhasedakClientTest.php
@@ -49,9 +49,10 @@ class GhasedakClientTest extends TestCase
         ]);
 
         $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
+        $response = $client->getAccountInformation();
 
-        $this->expectException(\Illuminate\Http\Client\RequestException::class);
-        $client->getAccountInformation();
+        $this->assertTrue($response->failed());
+        $this->assertEquals(401, $response->status());
     }
 
     public function testSendSingleSMSSuccess()
@@ -97,9 +98,10 @@ class GhasedakClientTest extends TestCase
         ]);
 
         $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
+        $response = $client->sendSingleSMS('invalid', '09121234567', 'Test');
 
-        $this->expectException(\Illuminate\Http\Client\RequestException::class);
-        $client->sendSingleSMS('invalid', '09121234567', 'Test');
+        $this->assertTrue($response->failed());
+        $this->assertEquals(400, $response->status());
     }
 
     public function testSendOtpWithParamsOneParameter()
@@ -225,9 +227,11 @@ class GhasedakClientTest extends TestCase
         ]);
 
         $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
+        $response = $client->getAccountInformation();
 
-        $this->expectException(\Illuminate\Http\Client\RequestException::class);
-        $client->getAccountInformation();
+        $this->assertTrue($response->failed());
+        $this->assertTrue($response->serverError());
+        $this->assertEquals(500, $response->status());
     }
 
     public function testClientReferenceIdFormat()

--- a/tests/Unit/Clients/GhasedakClientTest.php
+++ b/tests/Unit/Clients/GhasedakClientTest.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace HoomanMirghasemi\Sms\Tests\Unit\Clients;
+
+use HoomanMirghasemi\Sms\Clients\GhasedakClient;
+use HoomanMirghasemi\Sms\Tests\TestCase;
+use Illuminate\Support\Facades\Http;
+
+class GhasedakClientTest extends TestCase
+{
+    private string $baseApiUrl = 'https://gateway.ghasedak.me/rest/api/v1/WebService';
+    private string $apiKey = 'test-api-key-123';
+
+    public function testGetAccountInformationSuccess()
+    {
+        Http::fake([
+            'GetAccountInformation' => Http::response([
+                'isSuccess' => true,
+                'statusCode' => 200,
+                'message' => 'Success',
+                'data' => [
+                    'credit' => '50000'
+                ]
+            ], 200)
+        ]);
+
+        $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
+        $response = $client->getAccountInformation();
+
+        $this->assertTrue($response->successful());
+        $data = $response->json();
+        $this->assertTrue($data['isSuccess']);
+        $this->assertEquals('50000', $data['data']['credit']);
+
+        Http::assertSent(function ($request) {
+            return $request->hasHeader('ApiKey', $this->apiKey) &&
+                   $request->url() === $this->baseApiUrl . '/GetAccountInformation';
+        });
+    }
+
+    public function testGetAccountInformationFailure()
+    {
+        Http::fake([
+            'GetAccountInformation' => Http::response([
+                'isSuccess' => false,
+                'statusCode' => 401,
+                'message' => 'Invalid API key'
+            ], 401)
+        ]);
+
+        $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
+
+        $this->expectException(\Illuminate\Http\Client\RequestException::class);
+        $client->getAccountInformation();
+    }
+
+    public function testSendSingleSMSSuccess()
+    {
+        Http::fake([
+            'SendSingleSMS' => Http::response([
+                'isSuccess' => true,
+                'statusCode' => 200,
+                'message' => 'Message sent successfully',
+                'data' => [
+                    'lineNumber' => '30005088',
+                    'messageId' => '123456789'
+                ]
+            ], 200)
+        ]);
+
+        $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
+        $response = $client->sendSingleSMS('30005088', '09121234567', 'Test message');
+
+        $this->assertTrue($response->successful());
+        $data = $response->json();
+        $this->assertTrue($data['isSuccess']);
+        $this->assertEquals('30005088', $data['data']['lineNumber']);
+
+        Http::assertSent(function ($request) {
+            $body = $request->data();
+            return $request->hasHeader('ApiKey', $this->apiKey) &&
+                   $request->url() === $this->baseApiUrl . '/SendSingleSMS' &&
+                   $body['lineNumber'] === '30005088' &&
+                   $body['receptor'] === '09121234567' &&
+                   $body['message'] === 'Test message';
+        });
+    }
+
+    public function testSendSingleSMSFailure()
+    {
+        Http::fake([
+            'SendSingleSMS' => Http::response([
+                'isSuccess' => false,
+                'statusCode' => 400,
+                'message' => 'Invalid line number'
+            ], 400)
+        ]);
+
+        $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
+
+        $this->expectException(\Illuminate\Http\Client\RequestException::class);
+        $client->sendSingleSMS('invalid', '09121234567', 'Test');
+    }
+
+    public function testSendOtpWithParamsOneParameter()
+    {
+        Http::fake([
+            'SendOtpWithParams' => Http::response([
+                'isSuccess' => true,
+                'statusCode' => 200,
+                'message' => 'OTP sent successfully'
+            ], 200)
+        ]);
+
+        $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
+        $response = $client->sendOtpWithParams('VerificationCode', '09121234567', '123456');
+
+        $this->assertTrue($response->successful());
+
+        Http::assertSent(function ($request) {
+            $body = $request->data();
+            return $request->url() === $this->baseApiUrl . '/SendOtpWithParams' &&
+                   $body['templateName'] === 'VerificationCode' &&
+                   $body['receptors'][0]['mobile'] === '09121234567' &&
+                   isset($body['param1']) &&
+                   $body['param1'] === '123456';
+        });
+    }
+
+    public function testSendOtpWithParamsMultipleParameters()
+    {
+        Http::fake([
+            'SendOtpWithParams' => Http::response([
+                'isSuccess' => true,
+                'statusCode' => 200,
+                'message' => 'OTP sent successfully'
+            ], 200)
+        ]);
+
+        $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
+        $response = $client->sendOtpWithParams(
+            'OrderConfirmation',
+            '09121234567',
+            'John',
+            '5000',
+            'Order#123'
+        );
+
+        $this->assertTrue($response->successful());
+
+        Http::assertSent(function ($request) {
+            $body = $request->data();
+            return $body['templateName'] === 'OrderConfirmation' &&
+                   $body['param1'] === 'John' &&
+                   $body['param2'] === '5000' &&
+                   $body['param3'] === 'Order#123';
+        });
+    }
+
+    public function testSendOtpWithParamsNullParameters()
+    {
+        Http::fake([
+            'SendOtpWithParams' => Http::response([
+                'isSuccess' => true,
+                'statusCode' => 200,
+                'message' => 'OTP sent successfully'
+            ], 200)
+        ]);
+
+        $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
+        $response = $client->sendOtpWithParams(
+            'Template',
+            '09121234567',
+            'param1',
+            null,
+            'param3',
+            null
+        );
+
+        $this->assertTrue($response->successful());
+
+        Http::assertSent(function ($request) {
+            $body = $request->data();
+            return $body['param1'] === 'param1' &&
+                   !isset($body['param2']) &&
+                   $body['param3'] === 'param3' &&
+                   !isset($body['param4']);
+        });
+    }
+
+    public function testSendOtpWithParamsAllTenParameters()
+    {
+        Http::fake([
+            'SendOtpWithParams' => Http::response([
+                'isSuccess' => true,
+                'statusCode' => 200,
+                'message' => 'OTP sent successfully'
+            ], 200)
+        ]);
+
+        $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
+        $response = $client->sendOtpWithParams(
+            'Template',
+            '09121234567',
+            'p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8', 'p9', 'p10'
+        );
+
+        $this->assertTrue($response->successful());
+
+        Http::assertSent(function ($request) {
+            $body = $request->data();
+            for ($i = 1; $i <= 10; $i++) {
+                if (!isset($body["param$i"]) || $body["param$i"] !== "p$i") {
+                    return false;
+                }
+            }
+            return true;
+        });
+    }
+
+    public function testConnectionTimeout()
+    {
+        Http::fake([
+            'GetAccountInformation' => Http::response([], 500)
+        ]);
+
+        $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
+
+        $this->expectException(\Illuminate\Http\Client\RequestException::class);
+        $client->getAccountInformation();
+    }
+
+    public function testClientReferenceIdFormat()
+    {
+        Http::fake([
+            'SendOtpWithParams' => Http::response([
+                'isSuccess' => true,
+                'statusCode' => 200,
+                'message' => 'Success'
+            ], 200)
+        ]);
+
+        $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
+        $client->sendOtpWithParams('Template', '09121234567', 'test');
+
+        Http::assertSent(function ($request) {
+            $body = $request->data();
+            $clientRefId = $body['receptors'][0]['clientReferenceId'];
+            return str_starts_with($clientRefId, '09121234567:');
+        });
+    }
+}

--- a/tests/Unit/Clients/GhasedakClientTest.php
+++ b/tests/Unit/Clients/GhasedakClientTest.php
@@ -15,13 +15,13 @@ class GhasedakClientTest extends TestCase
     {
         Http::fake([
             'GetAccountInformation' => Http::response([
-                'isSuccess' => true,
+                'isSuccess'  => true,
                 'statusCode' => 200,
-                'message' => 'Success',
-                'data' => [
-                    'credit' => '50000'
-                ]
-            ], 200)
+                'message'    => 'Success',
+                'data'       => [
+                    'credit' => '50000',
+                ],
+            ], 200),
         ]);
 
         $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
@@ -33,8 +33,8 @@ class GhasedakClientTest extends TestCase
         $this->assertEquals('50000', $data['data']['credit']);
 
         Http::assertSent(function ($request) {
-            return $request->hasHeader('ApiKey', $this->apiKey) &&
-                   $request->url() === $this->baseApiUrl . '/GetAccountInformation';
+            return $request->hasHeader('ApiKey', $this->apiKey)
+                   && $request->url() === $this->baseApiUrl.'/GetAccountInformation';
         });
     }
 
@@ -42,10 +42,10 @@ class GhasedakClientTest extends TestCase
     {
         Http::fake([
             'GetAccountInformation' => Http::response([
-                'isSuccess' => false,
+                'isSuccess'  => false,
                 'statusCode' => 401,
-                'message' => 'Invalid API key'
-            ], 401)
+                'message'    => 'Invalid API key',
+            ], 401),
         ]);
 
         $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
@@ -59,14 +59,14 @@ class GhasedakClientTest extends TestCase
     {
         Http::fake([
             'SendSingleSMS' => Http::response([
-                'isSuccess' => true,
+                'isSuccess'  => true,
                 'statusCode' => 200,
-                'message' => 'Message sent successfully',
-                'data' => [
+                'message'    => 'Message sent successfully',
+                'data'       => [
                     'lineNumber' => '30005088',
-                    'messageId' => '123456789'
-                ]
-            ], 200)
+                    'messageId'  => '123456789',
+                ],
+            ], 200),
         ]);
 
         $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
@@ -79,11 +79,12 @@ class GhasedakClientTest extends TestCase
 
         Http::assertSent(function ($request) {
             $body = $request->data();
-            return $request->hasHeader('ApiKey', $this->apiKey) &&
-                   $request->url() === $this->baseApiUrl . '/SendSingleSMS' &&
-                   $body['lineNumber'] === '30005088' &&
-                   $body['receptor'] === '09121234567' &&
-                   $body['message'] === 'Test message';
+
+            return $request->hasHeader('ApiKey', $this->apiKey)
+                   && $request->url() === $this->baseApiUrl.'/SendSingleSMS'
+                   && '30005088' === $body['lineNumber']
+                   && '09121234567' === $body['receptor']
+                   && 'Test message' === $body['message'];
         });
     }
 
@@ -91,10 +92,10 @@ class GhasedakClientTest extends TestCase
     {
         Http::fake([
             'SendSingleSMS' => Http::response([
-                'isSuccess' => false,
+                'isSuccess'  => false,
                 'statusCode' => 400,
-                'message' => 'Invalid line number'
-            ], 400)
+                'message'    => 'Invalid line number',
+            ], 400),
         ]);
 
         $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
@@ -108,10 +109,10 @@ class GhasedakClientTest extends TestCase
     {
         Http::fake([
             'SendOtpWithParams' => Http::response([
-                'isSuccess' => true,
+                'isSuccess'  => true,
                 'statusCode' => 200,
-                'message' => 'OTP sent successfully'
-            ], 200)
+                'message'    => 'OTP sent successfully',
+            ], 200),
         ]);
 
         $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
@@ -121,11 +122,12 @@ class GhasedakClientTest extends TestCase
 
         Http::assertSent(function ($request) {
             $body = $request->data();
-            return $request->url() === $this->baseApiUrl . '/SendOtpWithParams' &&
-                   $body['templateName'] === 'VerificationCode' &&
-                   $body['receptors'][0]['mobile'] === '09121234567' &&
-                   isset($body['param1']) &&
-                   $body['param1'] === '123456';
+
+            return $request->url() === $this->baseApiUrl.'/SendOtpWithParams'
+                   && 'VerificationCode' === $body['templateName']
+                   && '09121234567' === $body['receptors'][0]['mobile']
+                   && isset($body['param1'])
+                   && '123456' === $body['param1'];
         });
     }
 
@@ -133,10 +135,10 @@ class GhasedakClientTest extends TestCase
     {
         Http::fake([
             'SendOtpWithParams' => Http::response([
-                'isSuccess' => true,
+                'isSuccess'  => true,
                 'statusCode' => 200,
-                'message' => 'OTP sent successfully'
-            ], 200)
+                'message'    => 'OTP sent successfully',
+            ], 200),
         ]);
 
         $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
@@ -145,17 +147,18 @@ class GhasedakClientTest extends TestCase
             '09121234567',
             'John',
             '5000',
-            'Order#123'
+            'Order#123',
         );
 
         $this->assertTrue($response->successful());
 
         Http::assertSent(function ($request) {
             $body = $request->data();
-            return $body['templateName'] === 'OrderConfirmation' &&
-                   $body['param1'] === 'John' &&
-                   $body['param2'] === '5000' &&
-                   $body['param3'] === 'Order#123';
+
+            return 'OrderConfirmation' === $body['templateName']
+                   && 'John' === $body['param1']
+                   && '5000' === $body['param2']
+                   && 'Order#123' === $body['param3'];
         });
     }
 
@@ -163,10 +166,10 @@ class GhasedakClientTest extends TestCase
     {
         Http::fake([
             'SendOtpWithParams' => Http::response([
-                'isSuccess' => true,
+                'isSuccess'  => true,
                 'statusCode' => 200,
-                'message' => 'OTP sent successfully'
-            ], 200)
+                'message'    => 'OTP sent successfully',
+            ], 200),
         ]);
 
         $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
@@ -176,17 +179,18 @@ class GhasedakClientTest extends TestCase
             'param1',
             null,
             'param3',
-            null
+            null,
         );
 
         $this->assertTrue($response->successful());
 
         Http::assertSent(function ($request) {
             $body = $request->data();
-            return $body['param1'] === 'param1' &&
-                   !isset($body['param2']) &&
-                   $body['param3'] === 'param3' &&
-                   !isset($body['param4']);
+
+            return 'param1' === $body['param1']
+                   && !isset($body['param2'])
+                   && 'param3' === $body['param3']
+                   && !isset($body['param4']);
         });
     }
 
@@ -194,17 +198,26 @@ class GhasedakClientTest extends TestCase
     {
         Http::fake([
             'SendOtpWithParams' => Http::response([
-                'isSuccess' => true,
+                'isSuccess'  => true,
                 'statusCode' => 200,
-                'message' => 'OTP sent successfully'
-            ], 200)
+                'message'    => 'OTP sent successfully',
+            ], 200),
         ]);
 
         $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
         $response = $client->sendOtpWithParams(
             'Template',
             '09121234567',
-            'p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8', 'p9', 'p10'
+            'p1',
+            'p2',
+            'p3',
+            'p4',
+            'p5',
+            'p6',
+            'p7',
+            'p8',
+            'p9',
+            'p10',
         );
 
         $this->assertTrue($response->successful());
@@ -216,6 +229,7 @@ class GhasedakClientTest extends TestCase
                     return false;
                 }
             }
+
             return true;
         });
     }
@@ -223,7 +237,7 @@ class GhasedakClientTest extends TestCase
     public function testConnectionTimeout()
     {
         Http::fake([
-            'GetAccountInformation' => Http::response([], 500)
+            'GetAccountInformation' => Http::response([], 500),
         ]);
 
         $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
@@ -238,10 +252,10 @@ class GhasedakClientTest extends TestCase
     {
         Http::fake([
             'SendOtpWithParams' => Http::response([
-                'isSuccess' => true,
+                'isSuccess'  => true,
                 'statusCode' => 200,
-                'message' => 'Success'
-            ], 200)
+                'message'    => 'Success',
+            ], 200),
         ]);
 
         $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
@@ -250,6 +264,7 @@ class GhasedakClientTest extends TestCase
         Http::assertSent(function ($request) {
             $body = $request->data();
             $clientRefId = $body['receptors'][0]['clientReferenceId'];
+
             return str_starts_with($clientRefId, '09121234567:');
         });
     }

--- a/tests/Unit/Clients/GhasedakClientTest.php
+++ b/tests/Unit/Clients/GhasedakClientTest.php
@@ -15,13 +15,13 @@ class GhasedakClientTest extends TestCase
     {
         Http::fake([
             'GetAccountInformation' => Http::response([
-                'isSuccess' => true,
+                'isSuccess'  => true,
                 'statusCode' => 200,
-                'message' => 'Success',
-                'data' => [
-                    'credit' => '50000'
-                ]
-            ], 200)
+                'message'    => 'Success',
+                'data'       => [
+                    'credit' => '50000',
+                ],
+            ], 200),
         ]);
 
         $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
@@ -33,8 +33,8 @@ class GhasedakClientTest extends TestCase
         $this->assertEquals('50000', $data['data']['credit']);
 
         Http::assertSent(function ($request) {
-            return $request->hasHeader('ApiKey', $this->apiKey) &&
-                   $request->url() === $this->baseApiUrl . '/GetAccountInformation';
+            return $request->hasHeader('ApiKey', $this->apiKey)
+                   && $request->url() === $this->baseApiUrl.'/GetAccountInformation';
         });
     }
 
@@ -42,10 +42,10 @@ class GhasedakClientTest extends TestCase
     {
         Http::fake([
             'GetAccountInformation' => Http::response([
-                'isSuccess' => false,
+                'isSuccess'  => false,
                 'statusCode' => 401,
-                'message' => 'Invalid API key'
-            ], 401)
+                'message'    => 'Invalid API key',
+            ], 401),
         ]);
 
         $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
@@ -59,14 +59,14 @@ class GhasedakClientTest extends TestCase
     {
         Http::fake([
             'SendSingleSMS' => Http::response([
-                'isSuccess' => true,
+                'isSuccess'  => true,
                 'statusCode' => 200,
-                'message' => 'Message sent successfully',
-                'data' => [
+                'message'    => 'Message sent successfully',
+                'data'       => [
                     'lineNumber' => '30005088',
-                    'messageId' => '123456789'
-                ]
-            ], 200)
+                    'messageId'  => '123456789',
+                ],
+            ], 200),
         ]);
 
         $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
@@ -79,11 +79,12 @@ class GhasedakClientTest extends TestCase
 
         Http::assertSent(function ($request) {
             $body = $request->data();
-            return $request->hasHeader('ApiKey', $this->apiKey) &&
-                   $request->url() === $this->baseApiUrl . '/SendSingleSMS' &&
-                   $body['lineNumber'] === '30005088' &&
-                   $body['receptor'] === '09121234567' &&
-                   $body['message'] === 'Test message';
+
+            return $request->hasHeader('ApiKey', $this->apiKey)
+                   && $request->url() === $this->baseApiUrl.'/SendSingleSMS'
+                   && '30005088' === $body['lineNumber']
+                   && '09121234567' === $body['receptor']
+                   && 'Test message' === $body['message'];
         });
     }
 
@@ -91,10 +92,10 @@ class GhasedakClientTest extends TestCase
     {
         Http::fake([
             'SendSingleSMS' => Http::response([
-                'isSuccess' => false,
+                'isSuccess'  => false,
                 'statusCode' => 400,
-                'message' => 'Invalid line number'
-            ], 400)
+                'message'    => 'Invalid line number',
+            ], 400),
         ]);
 
         $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
@@ -108,10 +109,10 @@ class GhasedakClientTest extends TestCase
     {
         Http::fake([
             'SendOtpWithParams' => Http::response([
-                'isSuccess' => true,
+                'isSuccess'  => true,
                 'statusCode' => 200,
-                'message' => 'OTP sent successfully'
-            ], 200)
+                'message'    => 'OTP sent successfully',
+            ], 200),
         ]);
 
         $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
@@ -121,11 +122,12 @@ class GhasedakClientTest extends TestCase
 
         Http::assertSent(function ($request) {
             $body = $request->data();
-            return $request->url() === $this->baseApiUrl . '/SendOtpWithParams' &&
-                   $body['templateName'] === 'VerificationCode' &&
-                   $body['receptors'][0]['mobile'] === '09121234567' &&
-                   isset($body['param1']) &&
-                   $body['param1'] === '123456';
+
+            return $request->url() === $this->baseApiUrl.'/SendOtpWithParams'
+                   && 'VerificationCode' === $body['templateName']
+                   && '09121234567' === $body['receptors'][0]['mobile']
+                   && isset($body['param1'])
+                   && '123456' === $body['param1'];
         });
     }
 
@@ -133,10 +135,10 @@ class GhasedakClientTest extends TestCase
     {
         Http::fake([
             'SendOtpWithParams' => Http::response([
-                'isSuccess' => true,
+                'isSuccess'  => true,
                 'statusCode' => 200,
-                'message' => 'OTP sent successfully'
-            ], 200)
+                'message'    => 'OTP sent successfully',
+            ], 200),
         ]);
 
         $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
@@ -145,17 +147,18 @@ class GhasedakClientTest extends TestCase
             '09121234567',
             'John',
             '5000',
-            'Order#123'
+            'Order#123',
         );
 
         $this->assertTrue($response->successful());
 
         Http::assertSent(function ($request) {
             $body = $request->data();
-            return $body['templateName'] === 'OrderConfirmation' &&
-                   $body['param1'] === 'John' &&
-                   $body['param2'] === '5000' &&
-                   $body['param3'] === 'Order#123';
+
+            return 'OrderConfirmation' === $body['templateName']
+                   && 'John' === $body['param1']
+                   && '5000' === $body['param2']
+                   && 'Order#123' === $body['param3'];
         });
     }
 
@@ -163,10 +166,10 @@ class GhasedakClientTest extends TestCase
     {
         Http::fake([
             'SendOtpWithParams' => Http::response([
-                'isSuccess' => true,
+                'isSuccess'  => true,
                 'statusCode' => 200,
-                'message' => 'OTP sent successfully'
-            ], 200)
+                'message'    => 'OTP sent successfully',
+            ], 200),
         ]);
 
         $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
@@ -176,17 +179,18 @@ class GhasedakClientTest extends TestCase
             'param1',
             null,
             'param3',
-            null
+            null,
         );
 
         $this->assertTrue($response->successful());
 
         Http::assertSent(function ($request) {
             $body = $request->data();
-            return $body['param1'] === 'param1' &&
-                   !isset($body['param2']) &&
-                   $body['param3'] === 'param3' &&
-                   !isset($body['param4']);
+
+            return 'param1' === $body['param1']
+                   && ! isset($body['param2'])
+                   && 'param3' === $body['param3']
+                   && ! isset($body['param4']);
         });
     }
 
@@ -194,28 +198,29 @@ class GhasedakClientTest extends TestCase
     {
         Http::fake([
             'SendOtpWithParams' => Http::response([
-                'isSuccess' => true,
+                'isSuccess'  => true,
                 'statusCode' => 200,
-                'message' => 'OTP sent successfully'
-            ], 200)
+                'message'    => 'OTP sent successfully',
+            ], 200),
         ]);
 
         $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
         $response = $client->sendOtpWithParams(
             'Template',
             '09121234567',
-            'p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8', 'p9', 'p10'
+            'p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8', 'p9', 'p10',
         );
 
         $this->assertTrue($response->successful());
 
         Http::assertSent(function ($request) {
             $body = $request->data();
-            for ($i = 1; $i <= 10; $i++) {
-                if (!isset($body["param$i"]) || $body["param$i"] !== "p$i") {
+            for ($i = 1; $i <= 10; ++$i) {
+                if (! isset($body["param$i"]) || $body["param$i"] !== "p$i") {
                     return false;
                 }
             }
+
             return true;
         });
     }
@@ -223,7 +228,7 @@ class GhasedakClientTest extends TestCase
     public function testConnectionTimeout()
     {
         Http::fake([
-            'GetAccountInformation' => Http::response([], 500)
+            'GetAccountInformation' => Http::response([], 500),
         ]);
 
         $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
@@ -238,10 +243,10 @@ class GhasedakClientTest extends TestCase
     {
         Http::fake([
             'SendOtpWithParams' => Http::response([
-                'isSuccess' => true,
+                'isSuccess'  => true,
                 'statusCode' => 200,
-                'message' => 'Success'
-            ], 200)
+                'message'    => 'Success',
+            ], 200),
         ]);
 
         $client = new GhasedakClient($this->baseApiUrl, $this->apiKey);
@@ -250,6 +255,7 @@ class GhasedakClientTest extends TestCase
         Http::assertSent(function ($request) {
             $body = $request->data();
             $clientRefId = $body['receptors'][0]['clientReferenceId'];
+
             return str_starts_with($clientRefId, '09121234567:');
         });
     }


### PR DESCRIPTION
Remove external dependency on ghasedaksms/php package and implement a custom GhasedakClient using Laravel's HTTP facade. This provides better control over HTTP operations and reduces external dependencies.

Key changes:
- Add GhasedakClient class with methods for SMS, OTP, and account info
- Refactor Ghasedak driver to use the new client implementation
- Add illuminate/http dependency to composer.json
- Update service provider binding to remove conditional class check
- Add configurable base_api_url option for custom endpoints
- Add coverage artifacts to .gitignore

Testing:
- Add comprehensive unit tests for GhasedakClient (10 tests)
- Expand integration tests for Ghasedak driver (17 tests)
- Achieve 100% code coverage for both classes
- Test all success/failure scenarios including network errors
- Test OTP templates with variable parameter counts (1-10 params)
- Test HTTP error responses and API-level error responses